### PR TITLE
✨ #25 - 토큰 갱신

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/controller/UsersController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/controller/UsersController.kt
@@ -1,7 +1,6 @@
 package com.teamsparta.tikitaka.domain.users.controller
 
-import com.teamsparta.tikitaka.domain.users.dto.SignUpRequest
-import com.teamsparta.tikitaka.domain.users.dto.UserDto
+import com.teamsparta.tikitaka.domain.users.dto.*
 import com.teamsparta.tikitaka.domain.users.service.v1.UsersService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -10,8 +9,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import com.teamsparta.tikitaka.domain.users.dto.LoginRequest
-import com.teamsparta.tikitaka.domain.users.dto.LoginResponse
 import jakarta.servlet.http.HttpServletRequest
 
 @RequestMapping("/api/v1/users")
@@ -42,5 +39,12 @@ class UsersController(
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(userService.logOut(token!!))
+    }
+
+    @PostMapping("/token/refresh")
+    fun tokenRefresh(@RequestBody tokenRefreshDto: TokenRefreshDto): ResponseEntity<LoginResponse> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(userService.validateRefreshTokenAndCreateToken(tokenRefreshDto.refreshToken))
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/dto/TokenRefreshDto.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/dto/TokenRefreshDto.kt
@@ -1,0 +1,5 @@
+package com.teamsparta.tikitaka.domain.users.dto
+
+data class TokenRefreshDto(
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersService.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersService.kt
@@ -9,4 +9,5 @@ interface UsersService {
     fun signUp(request: SignUpRequest): UserDto
     fun logIn(request: LoginRequest): LoginResponse
     fun logOut(token: String)
+    fun validateRefreshTokenAndCreateToken(refreshToken: String): LoginResponse
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersServiceImpl.kt
@@ -41,21 +41,32 @@ class UsersServiceImpl(
 
     override fun logIn(request: LoginRequest): LoginResponse {
         val user = usersRepository.findByEmail(request.email) ?: throw RuntimeException("임시")
-        return LoginResponse(
-            refreshToken = jwtPlugin.generateRefreshToken(
-                subject = user.id.toString(),
-                email = user.email
-            ),
-            accessToken = jwtPlugin.generateAccessToken(
-                subject = user.id.toString(),
-                email = user.email
-            )
-
+        val accessToken = jwtPlugin.generateAccessToken(
+            subject = user.id.toString(),
+            email = user.email
         )
+        val refreshToken = jwtPlugin.generateRefreshToken(
+            subject = user.id.toString(),
+            email = user.email
+        )
+        redisUtils.saveRefreshToken(refreshToken)
+        return LoginResponse(accessToken = accessToken, refreshToken = refreshToken)
     }
 
     override fun logOut(token: String) {
         redisUtils.setDataExpire(token, "blacklisted")
+    }
+
+    override fun validateRefreshTokenAndCreateToken(refreshToken: String): LoginResponse {
+        redisUtils.findByRefreshToken(refreshToken)
+            ?: throw InvalidCredentialException("만료되거나 찾을 수 없는 Refresh 토큰입니다. 재로그인이 필요합니다.")
+
+        val newTokenInfo = jwtPlugin.validateRefreshTokenAndCreateToken(refreshToken)
+        with(redisUtils) {
+            deleteByRefreshToken(refreshToken)
+            saveRefreshToken(newTokenInfo.refreshToken)
+        }
+        return newTokenInfo
     }
 
     fun isTokenBlacklisted(token: String): Boolean {

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/config/SecurityConfig.kt
@@ -31,7 +31,8 @@ class SecurityConfig(
                     "/v3/api-docs/**",
                     "/api/v1/users/log-in",
                     "/api/v1/users/sign-up",
-                    "/error"
+                    "/error",
+                    "/api/v1/users/token/refresh"
                 ).permitAll()
                     .anyRequest().authenticated()
             }

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/jwt/JwtPlugin.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/jwt/JwtPlugin.kt
@@ -1,5 +1,7 @@
 package com.teamsparta.tikitaka.infra.security.jwt
 
+import com.teamsparta.tikitaka.domain.common.exception.InvalidCredentialException
+import com.teamsparta.tikitaka.domain.users.dto.LoginResponse
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwts
@@ -52,5 +54,16 @@ class JwtPlugin(
             .claims(claims)
             .signWith(key)
             .compact()
+    }
+
+    fun validateRefreshTokenAndCreateToken(refreshToken: String): LoginResponse {
+        val claims = validateToken(refreshToken).getOrElse { throw InvalidCredentialException("Invalid Refresh Token") }.payload
+        val subject = claims.subject
+        val email = claims["email"].toString()
+
+        val newAccessToken = generateAccessToken(subject, email)
+        val newRefreshToken = generateRefreshToken(subject, email)
+
+        return LoginResponse(newAccessToken, newRefreshToken)
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#25 

## 📝작업 내용

* 로그인 시 발급한 refresh token을 저장하는 로직을 추가했습니다.
* refresh token 유효성 검증 후 새로운 accesstoken 및 refreshtoken을 생성하여 반환합니다.

### 스크린샷 (선택)
* 만료된 refresh token일 경우
<img src="https://github.com/user-attachments/assets/20efdab8-b56f-44c2-8d9d-a5d17e630d51" width="900"/>

*  토큰 반환
<img src="https://github.com/user-attachments/assets/d1bd83d0-f8eb-465b-8053-252876df210e" width="900"/>

## 💬리뷰 요구사항(선택)



## ✏️ 테스트 여부
- [x] 테스트완료
- (미완료 시) 이유 : 
