### PR TITLE
✨ #30 - QueryDSL 활용 Match 검색 기능 적용

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v1/MatchController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v1/MatchController.kt
@@ -6,10 +6,10 @@ import com.teamsparta.tikitaka.domain.match.dto.PostMatchRequest
 import com.teamsparta.tikitaka.domain.match.dto.UpdateMatchRequest
 import com.teamsparta.tikitaka.domain.match.service.v1.MatchService
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.awt.print.Pageable
 
 @RestController
 @RequestMapping("/matches")

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v1/MatchController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v1/MatchController.kt
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@RequestMapping("/matches")
+@RequestMapping("/api/v1/matches")
 class MatchController(
     private val matchService: MatchService,
 ) {
@@ -51,7 +51,7 @@ class MatchController(
             .body(matchService.getMatchDetails(matchId))
     }
 
-    @GetMapping("/search")
+    @GetMapping("/searches")
     fun searchMatch(
         pageable: Pageable,
         @RequestParam keyword: String,

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v1/MatchController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v1/MatchController.kt
@@ -5,9 +5,11 @@ import com.teamsparta.tikitaka.domain.match.dto.MatchStatusResponse
 import com.teamsparta.tikitaka.domain.match.dto.PostMatchRequest
 import com.teamsparta.tikitaka.domain.match.dto.UpdateMatchRequest
 import com.teamsparta.tikitaka.domain.match.service.v1.MatchService
+import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.awt.print.Pageable
 
 @RestController
 @RequestMapping("/matches")
@@ -49,4 +51,11 @@ class MatchController(
             .body(matchService.getMatchDetails(matchId))
     }
 
+    @GetMapping("/search")
+    fun searchMatch(
+        pageable: Pageable,
+        @RequestParam keyword: String,
+    ): ResponseEntity<Page<MatchResponse>> {
+        return ResponseEntity.status(HttpStatus.OK).body(matchService.searchMatch(pageable, keyword))
+    }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/model/Match.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/model/Match.kt
@@ -60,7 +60,7 @@ class Match(
                 content = content,
                 matchStatus = matchStatus,
                 teamId = teamId,
-                title = title,
+                title = title
             ).apply {
                 validateTitle(title)
                 validateMatchDate(matchDate)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/CustomMatchRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/CustomMatchRepository.kt
@@ -1,0 +1,9 @@
+package com.teamsparta.tikitaka.domain.match.repository
+
+import com.teamsparta.tikitaka.domain.match.dto.MatchResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface CustomMatchRepository {
+    fun searchMatchByPageableAndKeyword(pageable: Pageable, keyword: String?): Page<MatchResponse>
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/MatchRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/MatchRepository.kt
@@ -1,12 +1,9 @@
 package com.teamsparta.tikitaka.domain.match.repository
 
 import com.teamsparta.tikitaka.domain.match.model.Match
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface MatchRepository : JpaRepository<Match, Long>, CustomMatchRepository {
-    fun findByDeletedAtIsNull(pageable: Pageable): Page<Match>
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/MatchRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/MatchRepository.kt
@@ -2,9 +2,7 @@ package com.teamsparta.tikitaka.domain.match.repository
 
 import com.teamsparta.tikitaka.domain.match.model.Match
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
 
-@Repository
-interface MatchRepository : JpaRepository<Match, Long> {
+interface MatchRepository : JpaRepository<Match, Long>, CustomMatchRepository {
     fun findByDeletedAtIsNull(): List<Match>
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/MatchRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/MatchRepository.kt
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface MatchRepository : JpaRepository<Match, Long>, CustomMatchRepository {
-}
+interface MatchRepository : JpaRepository<Match, Long>, CustomMatchRepository

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/MatchRepositoryImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/MatchRepositoryImpl.kt
@@ -1,0 +1,56 @@
+package com.teamsparta.tikitaka.domain.match.repository
+
+import com.querydsl.core.BooleanBuilder
+import com.teamsparta.tikitaka.domain.match.dto.MatchResponse
+import com.teamsparta.tikitaka.domain.match.model.QMatch
+import com.teamsparta.tikitaka.infra.querydsl.QueryDslSupport
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+
+@Repository
+class MatchRepositoryImpl : CustomMatchRepository, QueryDslSupport() {
+    private val match = QMatch.match
+
+    override fun searchMatchByPageableAndKeyword(
+        pageable: Pageable,
+        keyword: String?
+    ): Page<MatchResponse> {
+        val whereClause = BooleanBuilder()
+
+        keyword?.let {
+            whereClause.and(
+                match.title.containsIgnoreCase(it)
+                    .or(match.content.containsIgnoreCase(it))
+                    .or(match.location.containsIgnoreCase(it))
+            )
+        }
+
+        val totalCount = queryFactory.select(match.count())
+            .from(match)
+            .where(whereClause)
+            .fetchOne() ?: 0L
+
+
+        val matches = queryFactory.selectFrom(match)
+            .where(whereClause)
+            .orderBy(match.createdAt.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        val matchResponse = matches.map { match ->
+            MatchResponse(
+                id = match.id!!,
+                teamId = match.teamId,
+                title = match.title,
+                matchDate = match.matchDate,
+                location = match.location,
+                content = match.content,
+                matchStatus = match.matchStatus
+            )
+        }
+        return PageImpl(matchResponse, pageable, totalCount)
+    }
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchService.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchService.kt
@@ -4,17 +4,14 @@ import com.teamsparta.tikitaka.domain.match.dto.MatchResponse
 import com.teamsparta.tikitaka.domain.match.dto.MatchStatusResponse
 import com.teamsparta.tikitaka.domain.match.dto.PostMatchRequest
 import com.teamsparta.tikitaka.domain.match.dto.UpdateMatchRequest
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface MatchService {
-
     fun postMatch(request: PostMatchRequest): MatchStatusResponse
     fun updateMatch(matchId: Long, request: UpdateMatchRequest): MatchStatusResponse
-
     fun deleteMatch(matchId: Long): MatchStatusResponse
-
     fun getMatches(): List<MatchResponse>
-
     fun getMatchDetails(matchId: Long): MatchResponse
-
-
+    fun searchMatch(pageable: Pageable, keyword: String): Page<MatchResponse>
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchServiceImpl.kt
@@ -6,6 +6,8 @@ import com.teamsparta.tikitaka.domain.match.dto.PostMatchRequest
 import com.teamsparta.tikitaka.domain.match.dto.UpdateMatchRequest
 import com.teamsparta.tikitaka.domain.match.model.Match
 import com.teamsparta.tikitaka.domain.match.repository.MatchRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -71,4 +73,7 @@ class MatchServiceImpl(
             ?: throw RuntimeException("Match not found") //todo : custom exception
     }
 
+    override fun searchMatch(pageable: Pageable, keyword: String): Page<MatchResponse> {
+        return matchRepository.searchMatchByPageableAndKeyword(pageable, keyword)
+    }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/controller/v1/MatchApplicationController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/controller/v1/MatchApplicationController.kt
@@ -25,14 +25,14 @@ class MatchApplicationController(
             .body(matchApplicationService.applyMatch(principal.id, request, matchId))
     }
 
-    @DeleteMapping("/{matchId}/match-applications/{applicationId}")
+    /* @DeleteMapping("/{matchId}/match-applications/{applicationId}")
     fun deleteMatchApplication(
         @AuthenticationPrincipal principal: UserPrincipal,
         @PathVariable applicationId: Long,
     ): ResponseEntity<Unit> {
         matchApplicationService.deleteMatchApplication(principal, applicationId)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
-    }
+    } */
 
     @PatchMapping("/{matchId}/match-applications/{applicationId}")
     fun replyMatchApplication(

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/service/v1/MatchApplicationService.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/service/v1/MatchApplicationService.kt
@@ -3,11 +3,11 @@ package com.teamsparta.tikitaka.domain.matchApplication.service.v1
 import com.teamsparta.tikitaka.domain.matchApplication.dto.CreateApplicationRequest
 import com.teamsparta.tikitaka.domain.matchApplication.dto.MatchApplicationResponse
 import com.teamsparta.tikitaka.domain.matchApplication.dto.ReplyApplicationRequest
-import com.teamsparta.tikitaka.infra.security.UserPrincipal
 
 interface MatchApplicationService {
     fun applyMatch(userId: Long, request: CreateApplicationRequest, matchId: Long): MatchApplicationResponse
-    fun deleteMatchApplication(principal: UserPrincipal, applicationId: Long)
+
+    // fun deleteMatchApplication(principal: UserPrincipal, applicationId: Long)
     fun replyMatchApplication(
         userId: Long,
         applicationId: Long,

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/service/v1/MatchApplicationServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/service/v1/MatchApplicationServiceImpl.kt
@@ -1,6 +1,5 @@
 package com.teamsparta.tikitaka.domain.matchApplication.service.v1
 
-import com.teamsparta.tikitaka.domain.common.exception.AccessDeniedException
 import com.teamsparta.tikitaka.domain.common.exception.ModelNotFoundException
 import com.teamsparta.tikitaka.domain.match.repository.MatchRepository
 import com.teamsparta.tikitaka.domain.matchApplication.dto.CreateApplicationRequest
@@ -10,7 +9,6 @@ import com.teamsparta.tikitaka.domain.matchApplication.model.ApproveStatus
 import com.teamsparta.tikitaka.domain.matchApplication.model.MatchApplication
 import com.teamsparta.tikitaka.domain.matchApplication.repository.MatchApplicationRepository
 import com.teamsparta.tikitaka.domain.users.repository.UsersRepository
-import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -33,7 +31,7 @@ class MatchApplicationServiceImpl
             .let { MatchApplicationResponse.from(it) }
     }
 
-    @Transactional
+    /* @Transactional
     override fun deleteMatchApplication(principal: UserPrincipal, applicationId: Long) {
         val matchApply = matchApplicationRepository.findByIdOrNull(applicationId) ?: throw ModelNotFoundException(
             "match",
@@ -44,7 +42,7 @@ class MatchApplicationServiceImpl
         )
         matchApply.delete()
         matchApply.approveStatus = ApproveStatus.CANCELLED
-    }
+    } */
 
     @Transactional
     override fun replyMatchApplication(

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/querydsl/QueryDslSupport.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/querydsl/QueryDslSupport.kt
@@ -1,0 +1,15 @@
+package com.teamsparta.tikitaka.infra.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+
+abstract class QueryDslSupport {
+    @PersistenceContext
+    protected lateinit var entityManager: EntityManager
+
+    protected val queryFactory: JPAQueryFactory
+        get() {
+            return JPAQueryFactory(entityManager)
+        }
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/config/SecurityConfig.kt
@@ -32,7 +32,8 @@ class SecurityConfig(
                     "/api/v1/users/log-in",
                     "/api/v1/users/sign-up",
                     "/error",
-                    "/api/v1/users/token/refresh"
+                    "/api/v1/users/token/refresh",
+                    "/api/v1/matches/searches"
                 ).permitAll()
                     .anyRequest().authenticated()
             }


### PR DESCRIPTION
## #️⃣연관된 이슈
 
> #30 

## 📝작업 내용

> QueryDslSupport 추가하여, 검색기능 QueryDsl을 통해 작성하였습니다.
> 기존 Match API를 함께 작업을 진행하다 보니, 충돌이 발생하여 해당 부분 함께 해결하였습니다.
> 검색 시 타이틀이나 내용, 장소에 키워드가 포함되는 매치들은 모두 조회가 가능합니다. 

## 💬리뷰 요구사항

> QueryDsl 부분에서 보다 개선이 필요하거나, 더 나은 아이디어가 있다면 말씀해주세요!

## ✏️ 테스트 여부
- [x] 테스트완료
