### PR TITLE
✨ #40 - TeamMember Role에 따른 권한부여 설정 진행

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/controller/v1/MatchApplicationController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/controller/v1/MatchApplicationController.kt
@@ -4,6 +4,8 @@ import com.teamsparta.tikitaka.domain.matchApplication.dto.CreateApplicationRequ
 import com.teamsparta.tikitaka.domain.matchApplication.dto.MatchApplicationResponse
 import com.teamsparta.tikitaka.domain.matchApplication.dto.ReplyApplicationRequest
 import com.teamsparta.tikitaka.domain.matchApplication.service.v1.MatchApplicationService
+import com.teamsparta.tikitaka.domain.team.model.teamMember.TeamRole
+import com.teamsparta.tikitaka.infra.security.CustomPreAuthorize
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -13,7 +15,8 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/v1/matches")
 @RestController
 class MatchApplicationController(
-    private val matchApplicationService: MatchApplicationService
+    private val matchApplicationService: MatchApplicationService,
+    private val preAuthorize: CustomPreAuthorize,
 ) {
     @PostMapping("/{matchId}/match-applications")
     fun applyMatch(
@@ -21,8 +24,10 @@ class MatchApplicationController(
         @PathVariable matchId: Long,
         @RequestBody request: CreateApplicationRequest
     ): ResponseEntity<MatchApplicationResponse> {
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(matchApplicationService.applyMatch(principal.id, request, matchId))
+        return preAuthorize.hasAnyRole(principal, setOf(TeamRole.LEADER, TeamRole.SUB_LEADER)) {
+            ResponseEntity.status(HttpStatus.CREATED)
+                .body(matchApplicationService.applyMatch(principal.id, request, matchId))
+        }
     }
 
     /* @DeleteMapping("/{matchId}/match-applications/{applicationId}")

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/teamMember/TeamMember.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/teamMember/TeamMember.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 @SQLRestriction("deleted_at is null")
 class TeamMember(
     @Column(name = "user_id", nullable = false)
-    val UserId: Long,
+    val userId: Long,
 
     @ManyToOne
     @JoinColumn(name = "team_id", nullable = false)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/teamMember/TeamRole.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/teamMember/TeamRole.kt
@@ -1,7 +1,7 @@
 package com.teamsparta.tikitaka.domain.team.model.teamMember
 
 enum class TeamRole {
-    USER, LEADER, SUB_LEADER, MEMBER;
+    LEADER, SUB_LEADER, MEMBER;
 
     companion object {
         fun fromString(teamRole: String): TeamRole {

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/teamMember/TeamRole.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/teamMember/TeamRole.kt
@@ -1,7 +1,7 @@
 package com.teamsparta.tikitaka.domain.team.model.teamMember
 
 enum class TeamRole {
-    LEADER, SUB_LEADER, MEMBER;
+    USER, LEADER, SUB_LEADER, MEMBER;
 
     companion object {
         fun fromString(teamRole: String): TeamRole {

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/teamMember/TeamMemberRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/teamMember/TeamMemberRepository.kt
@@ -1,0 +1,8 @@
+package com.teamsparta.tikitaka.domain.team.repository.teamMember
+
+import com.teamsparta.tikitaka.domain.team.model.teamMember.TeamMember
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TeamMemberRepository : JpaRepository<TeamMember, Long> {
+    fun findByUserId(userId: Long): TeamMember
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersServiceImpl.kt
@@ -2,14 +2,8 @@ package com.teamsparta.tikitaka.domain.users.service.v1
 
 import com.teamsparta.tikitaka.domain.common.exception.InvalidCredentialException
 import com.teamsparta.tikitaka.domain.common.util.RedisUtils
-import com.teamsparta.tikitaka.domain.users.dto.LoginRequest
-import com.teamsparta.tikitaka.domain.users.dto.LoginResponse
-import com.teamsparta.tikitaka.domain.users.dto.NameRequest
-import com.teamsparta.tikitaka.domain.users.dto.NameResponse
-import com.teamsparta.tikitaka.domain.users.dto.PasswordRequest
-import com.teamsparta.tikitaka.domain.users.dto.PasswordResponse
-import com.teamsparta.tikitaka.domain.users.dto.SignUpRequest
-import com.teamsparta.tikitaka.domain.users.dto.UserDto
+import com.teamsparta.tikitaka.domain.team.repository.teamMember.TeamMemberRepository
+import com.teamsparta.tikitaka.domain.users.dto.*
 import com.teamsparta.tikitaka.domain.users.model.Users
 import com.teamsparta.tikitaka.domain.users.repository.UsersRepository
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
@@ -23,8 +17,9 @@ import org.springframework.transaction.annotation.Transactional
 class UsersServiceImpl(
     private val usersRepository: UsersRepository,
     private val passwordEncoder: PasswordEncoder,
+    private val teamMemberRepository: TeamMemberRepository,
     private val jwtPlugin: JwtPlugin,
-    private val redisUtils: RedisUtils
+    private val redisUtils: RedisUtils,
 ) : UsersService {
     @Transactional
     override fun signUp(request: SignUpRequest): UserDto {
@@ -54,13 +49,23 @@ class UsersServiceImpl(
         if (!passwordEncoder.matches(request.password, user.password)) {
             throw RuntimeException("비밀번호가 맞지 않습니다")
         }
+
+
+        val role = if (user.teamStatus) {
+            val teamMember = teamMemberRepository.findByUserId(user.id!!)
+            teamMember.teamRole.name
+        } else {
+            "USER" // "TeamRole 에 대한 권한을 주지 않는다" 로 수정 필요
+        }
         val accessToken = jwtPlugin.generateAccessToken(
             subject = user.id.toString(),
-            email = user.email
+            email = user.email,
+            role = role
         )
         val refreshToken = jwtPlugin.generateRefreshToken(
             subject = user.id.toString(),
-            email = user.email
+            email = user.email,
+            role = role
         )
         redisUtils.saveRefreshToken(refreshToken)
         return LoginResponse(accessToken = accessToken, refreshToken = refreshToken)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersServiceImpl.kt
@@ -51,11 +51,13 @@ class UsersServiceImpl(
         }
 
 
-        val role = if (user.teamStatus) {
-            val teamMember = teamMemberRepository.findByUserId(user.id!!)
-            teamMember.teamRole.name
-        } else {
-            "USER" // "TeamRole 에 대한 권한을 주지 않는다" 로 수정 필요
+        val role = when {
+            user.teamStatus -> {
+                val teamMember = teamMemberRepository.findByUserId(user.id!!)
+                teamMember.teamRole.name
+            }
+
+            else -> null
         }
         val accessToken = jwtPlugin.generateAccessToken(
             subject = user.id.toString(),

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/CustomPreAuthorize.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/CustomPreAuthorize.kt
@@ -1,0 +1,17 @@
+package com.teamsparta.tikitaka.infra.security
+
+import com.teamsparta.tikitaka.domain.common.exception.AccessDeniedException
+import com.teamsparta.tikitaka.domain.team.model.teamMember.TeamRole
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.stereotype.Component
+
+@Component
+class CustomPreAuthorize {
+    fun <T> hasAnyRole(principal: UserPrincipal, validRoles: Set<TeamRole>, action: () -> T): T {
+        val validAuthorities = validRoles.map { SimpleGrantedAuthority("ROLE_$it") }.toSet()
+        if (principal.authorities.none { it in validAuthorities }) {
+            throw AccessDeniedException("Not allowed to this API")
+        }
+        return action()
+    }
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/UserPrincipal.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/UserPrincipal.kt
@@ -12,6 +12,6 @@ data class UserPrincipal(
     constructor(
         id: Long,
         name: String,
-        role: TeamRole,
-    ) : this(id, name, setOf(SimpleGrantedAuthority("ROLE_$role")))
+        role: TeamRole?,
+    ) : this(id, name, if (role == null) emptySet<GrantedAuthority>() else setOf(SimpleGrantedAuthority("ROLE_$role")))
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/UserPrincipal.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/UserPrincipal.kt
@@ -1,5 +1,6 @@
 package com.teamsparta.tikitaka.infra.security
 
+import com.teamsparta.tikitaka.domain.team.model.teamMember.TeamRole
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
@@ -7,11 +8,10 @@ data class UserPrincipal(
     val id: Long,
     val name: String,
     val authorities: Collection<GrantedAuthority>
-)
-{
-    constructor(id: Long, email: String, role: Set<String>) : this(
-        id,
-        email,
-        role.map { SimpleGrantedAuthority("ROLE_$it") }
-    )
+) {
+    constructor(
+        id: Long,
+        name: String,
+        role: TeamRole,
+    ) : this(id, name, setOf(SimpleGrantedAuthority("ROLE_$role")))
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/jwt/JwtAuthenticationFilter.kt
@@ -34,7 +34,7 @@ class JwtAuthenticationFilter(
             jwtPlugin.validateToken(jwt).onSuccess { claims ->
                 val userId = claims.payload.subject.toLong()
                 val name = claims.payload.get("email", String::class.java)
-                val role = TeamRole.valueOf(claims.payload["role"] as String)
+                val role: TeamRole? = claims.payload["role"]?.let { TeamRole.valueOf(it as String) }
 
                 val principal = UserPrincipal(
                     id = userId, name = name, role = role

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/jwt/JwtAuthenticationFilter.kt
@@ -1,5 +1,6 @@
 package com.teamsparta.tikitaka.infra.security.jwt
 
+import com.teamsparta.tikitaka.domain.team.model.teamMember.TeamRole
 import com.teamsparta.tikitaka.domain.users.service.v1.UsersServiceImpl
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import jakarta.servlet.FilterChain
@@ -13,21 +14,16 @@ import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
 class JwtAuthenticationFilter(
-    private val jwtPlugin: JwtPlugin,
-    private val usersService: UsersServiceImpl
-) : OncePerRequestFilter()
-{
+    private val jwtPlugin: JwtPlugin, private val usersService: UsersServiceImpl
+) : OncePerRequestFilter() {
 
     companion object {
         private val BEARER_PATTERN = Regex("^Bearer (.+?)$")
     }
 
     override fun doFilterInternal(
-        request: HttpServletRequest,
-        response: HttpServletResponse,
-        filterChain: FilterChain
-    )
-    {
+        request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain
+    ) {
         val jwt = request.getBearerToken()
 
         if (jwt != null) {
@@ -35,35 +31,32 @@ class JwtAuthenticationFilter(
                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token is blacklisted")
                 return
             }
-            jwtPlugin.validateToken(jwt)
-                .onSuccess {
-                    val userId = it.payload.subject.toLong()
-                    val email = it.payload.get("email", String::class.java)
-                    val role = it.payload.get("role", String::class.java)
+            jwtPlugin.validateToken(jwt).onSuccess { claims ->
+                val userId = claims.payload.subject.toLong()
+                val name = claims.payload.get("email", String::class.java)
+                val role = TeamRole.valueOf(claims.payload["role"] as String)
 
-                    val principal = UserPrincipal(
-                        id = userId,
-                        email = email,
-                        role = setOf(role)
-                    )
+                val principal = UserPrincipal(
+                    id = userId, name = name, role = role
+                )
 
-                    val authentication = JwtAuthenticationToken(
-                        principal = principal,
-                        details = WebAuthenticationDetailsSource().buildDetails(request)
-                    )
-                    SecurityContextHolder.getContext().authentication = authentication
-                    request.setAttribute("accessToken", jwt)
-                }
-                .onFailure {
-                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token")
-                    return
-                }
+                val authentication = JwtAuthenticationToken(
+                    principal = principal, details = WebAuthenticationDetailsSource().buildDetails(request)
+                )
+                SecurityContextHolder.getContext().authentication = authentication
+                request.setAttribute("accessToken", jwt)
+            }.onFailure {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid token")
+                return
+            }
         }
         filterChain.doFilter(request, response)
     }
 
     private fun HttpServletRequest.getBearerToken(): String? {
-        val headerValue = this.getHeader(HttpHeaders.AUTHORIZATION) ?: return null
-        return BEARER_PATTERN.find(headerValue)?.groupValues?.get(1)
+        val header = this.getHeader(HttpHeaders.AUTHORIZATION) ?: return null
+        val prefix = "Bearer "
+        return if (header.startsWith(prefix, ignoreCase = true)) header.substring(prefix.length)
+        else null
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/jwt/JwtPlugin.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/jwt/JwtPlugin.kt
@@ -62,7 +62,7 @@ class JwtPlugin(
             validateToken(refreshToken).getOrElse { throw InvalidCredentialException("Invalid Refresh Token") }.payload
         val subject = claims.subject
         val email = claims["email"].toString()
-        val role = TeamRole.valueOf(claims["role"] as String)
+        val role: TeamRole? = claims["role"]?.let { TeamRole.valueOf(it as String) }
 
         val newAccessToken = generateAccessToken(subject, email, role.toString())
         val newRefreshToken = generateRefreshToken(subject, email, role.toString())


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 

## 📝작업 내용

> Controller 내부 간결한 권한 부여 처리를 위해, CustomPreAuthorize Class 생성
> Role의 경우, TeamRole을 타입으로 설정하여 TeamRole에 포함되지 않을 경우 Null 처리
> MatchApplication Method 중 ApplyMatch 를 통해 Test 진행
> Version 2 Or 3에서 User에 Role ADMIN 추가될 경우도 고려하여 추후 작업진행이 필요해보입니다!

## ✏️ 테스트 여부
- [x] 테스트완료
