### PR TITLE
:bug: #51 - Users deletedAt 디폴트 값 삭제

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/model/Users.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/model/Users.kt
@@ -24,7 +24,7 @@ class Users(
     var createdAt: LocalDateTime = LocalDateTime.now(),
 
     @Column(name = "deleted_at", nullable = true)
-    var deletedAt: LocalDateTime = LocalDateTime.now(),
+    var deletedAt: LocalDateTime? = null,
 )
 {
     @Id


### PR DESCRIPTION
## #️⃣연관된 이슈

#51 

## 📝작업 내용

Users deletedAt에 디폴트 값이 설정되어 있는 부분을 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


## ✏️ 테스트 여부
- [ ] 테스트완료