### PR TITLE
✨ #49 - MatchApplication API 내부 Authority 적용

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/common/exception/GlobalExceptionHandler.kt
@@ -53,4 +53,11 @@ class GlobalExceptionHandler {
             .body(ErrorResponse(message = e.message))
     }
 
+    @ExceptionHandler(TeamAlreadyAppliedException::class)
+    fun handleTeamAlreadyAppliedException(e: TeamAlreadyAppliedException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(message = e.message))
+    }
+
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/common/exception/TeamAlreadyAppliedException.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/common/exception/TeamAlreadyAppliedException.kt
@@ -1,0 +1,3 @@
+package com.teamsparta.tikitaka.domain.common.exception
+
+class TeamAlreadyAppliedException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v1/MatchController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v1/MatchController.kt
@@ -7,11 +7,13 @@ import com.teamsparta.tikitaka.domain.match.dto.PostMatchRequest
 import com.teamsparta.tikitaka.domain.match.dto.UpdateMatchRequest
 import com.teamsparta.tikitaka.domain.match.model.SortCriteria
 import com.teamsparta.tikitaka.domain.match.service.v1.MatchService
+import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -19,10 +21,12 @@ import org.springframework.web.bind.annotation.*
 class MatchController(
     private val matchService: MatchService,
 ) {
-    //@PreAuthorize("hasRole('LEADER')") //todo : 리더 외 권한 부여 ?
     @PostMapping("/create")
-    fun postMatch(@RequestBody request: PostMatchRequest): ResponseEntity<MatchStatusResponse> {
-        return ResponseEntity.status(HttpStatus.CREATED).body(matchService.postMatch(request))
+    fun postMatch(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @RequestBody request: PostMatchRequest
+    ): ResponseEntity<MatchStatusResponse> {
+        return ResponseEntity.status(HttpStatus.CREATED).body(matchService.postMatch(principal, request))
     }
 
     //@PreAuthorize("hasRole('LEADER')") //todo : 리더 외 작성자

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/MatchResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/MatchResponse.kt
@@ -8,6 +8,7 @@ data class MatchResponse(
 
     val id: Long,
     val teamId: Long,
+    val userId: Long,
     val title: String,
     val matchDate: LocalDateTime,
     val region: Region,
@@ -21,6 +22,7 @@ data class MatchResponse(
         fun from(match: Match) = MatchResponse(
             id = match.id!!,
             teamId = match.teamId,
+            userId = match.userId,
             title = match.title,
             matchDate = match.matchDate,
             location = match.location,

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/model/Match.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/model/Match.kt
@@ -31,7 +31,10 @@ class Match(
     var matchStatus: Boolean = false,
 
     @Column(name = "post_team_id", nullable = false)
-    var teamId: Long
+    var teamId: Long,
+
+    @Column(name = "post_user_id", nullable = false)
+    var userId: Long
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -60,6 +63,7 @@ class Match(
             teamId: Long,
             title: String,
             region: Region,
+            userId: Long
         ): Match {
             return Match(
                 matchDate = matchDate,
@@ -69,6 +73,7 @@ class Match(
                 teamId = teamId,
                 title = title,
                 region = region,
+                userId = userId
             ).apply {
                 validateTitle(title)
                 validateMatchDate(matchDate)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/MatchRepositoryImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/MatchRepositoryImpl.kt
@@ -48,6 +48,7 @@ class MatchRepositoryImpl : CustomMatchRepository, QueryDslSupport() {
             MatchResponse(
                 id = match.id!!,
                 teamId = match.teamId,
+                userId = match.userId,
                 title = match.title,
                 matchDate = match.matchDate,
                 location = match.location,
@@ -89,6 +90,7 @@ class MatchRepositoryImpl : CustomMatchRepository, QueryDslSupport() {
             MatchResponse(
                 id = match.id!!,
                 teamId = match.teamId,
+                userId = match.userId,
                 title = match.title,
                 matchDate = match.matchDate,
                 location = match.location,
@@ -142,6 +144,7 @@ class MatchRepositoryImpl : CustomMatchRepository, QueryDslSupport() {
             MatchResponse(
                 id = match.id!!,
                 teamId = match.teamId,
+                userId = match.userId,
                 title = match.title,
                 matchDate = match.matchDate,
                 location = match.location,

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchService.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchService.kt
@@ -6,12 +6,13 @@ import com.teamsparta.tikitaka.domain.match.dto.MatchStatusResponse
 import com.teamsparta.tikitaka.domain.match.dto.PostMatchRequest
 import com.teamsparta.tikitaka.domain.match.dto.UpdateMatchRequest
 import com.teamsparta.tikitaka.domain.match.model.SortCriteria
+import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface MatchService {
 
-    fun postMatch(request: PostMatchRequest): MatchStatusResponse
+    fun postMatch(principal: UserPrincipal, request: PostMatchRequest): MatchStatusResponse
     fun updateMatch(matchId: Long, request: UpdateMatchRequest): MatchStatusResponse
     fun deleteMatch(matchId: Long): MatchStatusResponse
     fun getMatches(pageable: Pageable): Page<MatchResponse>

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchServiceImpl.kt
@@ -8,6 +8,7 @@ import com.teamsparta.tikitaka.domain.match.dto.UpdateMatchRequest
 import com.teamsparta.tikitaka.domain.match.model.Match
 import com.teamsparta.tikitaka.domain.match.model.SortCriteria
 import com.teamsparta.tikitaka.domain.match.repository.MatchRepository
+import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -22,9 +23,7 @@ class MatchServiceImpl(
     ) : MatchService {
 
     @Transactional
-    override fun postMatch(
-        request: PostMatchRequest
-    ): MatchStatusResponse {
+    override fun postMatch(principal: UserPrincipal, request: PostMatchRequest): MatchStatusResponse {
 
         matchRepository.save(
             Match.of(
@@ -34,6 +33,7 @@ class MatchServiceImpl(
                 content = request.content,
                 matchStatus = false,
                 teamId = request.teamId,
+                userId = principal.id,
                 region = request.region,
             )
         )

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/controller/v1/MatchApplicationController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/controller/v1/MatchApplicationController.kt
@@ -30,14 +30,14 @@ class MatchApplicationController(
         }
     }
 
-    /* @DeleteMapping("/{matchId}/match-applications/{applicationId}")
+    @DeleteMapping("/{matchId}/match-applications/{applicationId}")
     fun deleteMatchApplication(
         @AuthenticationPrincipal principal: UserPrincipal,
         @PathVariable applicationId: Long,
     ): ResponseEntity<Unit> {
         matchApplicationService.deleteMatchApplication(principal, applicationId)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
-    } */
+    }
 
     @PatchMapping("/{matchId}/match-applications/{applicationId}")
     fun replyMatchApplication(

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/repository/CustomMatchApplicationRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/repository/CustomMatchApplicationRepository.kt
@@ -1,0 +1,8 @@
+package com.teamsparta.tikitaka.domain.matchApplication.repository
+
+import com.teamsparta.tikitaka.domain.matchApplication.model.MatchApplication
+import java.time.LocalDate
+
+interface CustomMatchApplicationRepository {
+    fun findByTeamIdAndMatchDate(teamId: Long, matchDate: LocalDate): List<MatchApplication>
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/repository/MatchApplicationRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/repository/MatchApplicationRepository.kt
@@ -3,5 +3,4 @@ package com.teamsparta.tikitaka.domain.matchApplication.repository
 import com.teamsparta.tikitaka.domain.matchApplication.model.MatchApplication
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface MatchApplicationRepository: JpaRepository<MatchApplication, Long> {
-}
+interface MatchApplicationRepository : JpaRepository<MatchApplication, Long>, CustomMatchApplicationRepository

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/repository/MatchApplicationRepositoryImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/repository/MatchApplicationRepositoryImpl.kt
@@ -1,0 +1,27 @@
+@file:JvmName("MatchApplicationRepositoryKt")
+
+package com.teamsparta.tikitaka.domain.matchApplication.repository
+
+import com.teamsparta.tikitaka.domain.match.model.QMatch
+import com.teamsparta.tikitaka.domain.matchApplication.model.MatchApplication
+import com.teamsparta.tikitaka.domain.matchApplication.model.QMatchApplication
+import com.teamsparta.tikitaka.infra.querydsl.QueryDslSupport
+import java.time.LocalDate
+
+class MatchApplicationRepositoryImpl : CustomMatchApplicationRepository, QueryDslSupport() {
+
+    override fun findByTeamIdAndMatchDate(teamId: Long, matchDate: LocalDate): List<MatchApplication> {
+        val qMatchApplication = QMatchApplication.matchApplication
+        val qMatch = QMatch.match
+
+        return queryFactory.selectFrom(qMatchApplication)
+            .join(qMatchApplication.matchPost, qMatch)
+            .where(
+                qMatchApplication.applyTeamId.eq(teamId)
+                    .and(qMatch.matchDate.year().eq(matchDate.year))
+                    .and(qMatch.matchDate.month().eq(matchDate.monthValue))
+                    .and(qMatch.matchDate.dayOfMonth().eq(matchDate.dayOfMonth))
+            )
+            .fetch()
+    }
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/repository/MatchApplicationRepositoryImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/repository/MatchApplicationRepositoryImpl.kt
@@ -10,9 +10,10 @@ import java.time.LocalDate
 
 class MatchApplicationRepositoryImpl : CustomMatchApplicationRepository, QueryDslSupport() {
 
+    private val qMatchApplication = QMatchApplication.matchApplication
+    private val qMatch = QMatch.match
+
     override fun findByTeamIdAndMatchDate(teamId: Long, matchDate: LocalDate): List<MatchApplication> {
-        val qMatchApplication = QMatchApplication.matchApplication
-        val qMatch = QMatch.match
 
         return queryFactory.selectFrom(qMatchApplication)
             .join(qMatchApplication.matchPost, qMatch)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/service/v1/MatchApplicationServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/service/v1/MatchApplicationServiceImpl.kt
@@ -69,27 +69,21 @@ class MatchApplicationServiceImpl
         usersRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User", userId)
         val (approveStatus) = request
 
-        // 현재의 applicationId의 approveStatus가 CANCELLED일 경우로 수정
         if (approveStatus == ApproveStatus.CANCELLED.toString()) {
             throw IllegalStateException("Cannot modify application with status CANCELLED")
         }
 
-
-        //ApplicationId가 존재하는지 여부를 체크
         val matchApply = matchApplicationRepository.findByIdOrNull(applicationId) ?: throw ModelNotFoundException(
             "MatchApplication",
             applicationId
         )
 
-        //조회한 신청이 어떤 매치인지 조회
         val match = matchApply.matchPost
         val matchUserId = match.userId
 
-        //현재 해당 API에 접근을 시도하는 사용자가 PostMatch한 팀의 소속인지 체크
         val userTeamMember = teamMemberRepository.findByUserIdAndTeamId(userId, match.teamId)
             ?: throw ModelNotFoundException("TeamMember", userId)
 
-        // 만약 해당  API에 접근을 시도한 사용자가 MatchPost한 사용자와 다를경우, MatchPost한 사용자가 속한 팀의 리더가 맞는지 체크
         if (userId != matchUserId) {
             val teamLeader = teamMemberRepository.findByUserId(userId)
             if (teamLeader.teamRole != TeamRole.LEADER && userTeamMember.teamRole != TeamRole.LEADER) {

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/service/v1/MatchApplicationServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/service/v1/MatchApplicationServiceImpl.kt
@@ -84,8 +84,7 @@ class MatchApplicationServiceImpl
             ?: throw ModelNotFoundException("TeamMember", userId)
 
         if (userId != matchUserId) {
-            val teamLeader = teamMemberRepository.findByUserId(userId)
-            if (teamLeader.teamRole != TeamRole.LEADER && userTeamMember.teamRole != TeamRole.LEADER) {
+            if (userTeamMember.teamRole != TeamRole.LEADER) {
                 throw AccessDeniedException("Only the author or the team leader can respond to this application")
             }
         }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/service/v1/MatchApplicationServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/matchApplication/service/v1/MatchApplicationServiceImpl.kt
@@ -2,6 +2,7 @@ package com.teamsparta.tikitaka.domain.matchApplication.service.v1
 
 import com.teamsparta.tikitaka.domain.common.exception.AccessDeniedException
 import com.teamsparta.tikitaka.domain.common.exception.ModelNotFoundException
+import com.teamsparta.tikitaka.domain.common.exception.TeamAlreadyAppliedException
 import com.teamsparta.tikitaka.domain.match.repository.MatchRepository
 import com.teamsparta.tikitaka.domain.matchApplication.dto.CreateApplicationRequest
 import com.teamsparta.tikitaka.domain.matchApplication.dto.MatchApplicationResponse
@@ -34,7 +35,7 @@ class MatchApplicationServiceImpl
 
         val existingApplications = matchApplicationRepository.findByTeamIdAndMatchDate(teamId, matchDate)
         if (existingApplications.any { it.approveStatus == ApproveStatus.WAITING || it.approveStatus == ApproveStatus.APPROVE }) {
-            throw RuntimeException("Your team already has a pending or approved application for the same match date.")
+            throw TeamAlreadyAppliedException("Your team already has a pending or approved application for the same match date.")
         }
 
         return matchApplicationRepository.save(MatchApplication.of(matchPost, teamId, userId))

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/Service/v1/TeamServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/Service/v1/TeamServiceImpl.kt
@@ -38,7 +38,7 @@ class TeamServiceImpl(
             page,
             size
         )
-
+    }
 
     @Transactional
     override fun createTeam(

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/teamMember/TeamMemberRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/teamMember/TeamMemberRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface TeamMemberRepository : JpaRepository<TeamMember, Long> {
     fun findByUserId(userId: Long): TeamMember
+    fun findByUserIdAndTeamId(userId: Long, teamId: Long): TeamMember?
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #49

## 📝작업 내용

> 이전 Conflict 해결 과정에서 발생한 Error 처리
> Match Table 내 권한 관련 접근을 위해, UserId Column 추가 (Match를 Post한 사용자의 Id)
> replyMatchApplication 관련 예외처리 추가 진행
> 사용자가 Match를 Post한 사용자가 아니거나, Post한 사용자의 TeamLeader가 아닐 경우 예외처리 진행 (해당 API에 접근 불가능)
> 매치 신청 시, 만약 동일한 날짜에 또다른 신청이 있고, 해당 신청의 응답상태가 승인이거나 대기중일 경우 신청 불가

## 💬리뷰 요구사항

> 예외처리가 많다보니 관련 부분 꼼꼼하게 이해하고, 리뷰 부탁드리겠습니다.. 일부러 Commit 내역 별 주석 달아놓은 것도 있어요! 보면 이해하기 쉬울 거에요!

## ✏️ 테스트 여부
- [x] 테스트완료
