### PR TITLE
✨ #54 - 팀 관련 기능 권한 적용 및 팀 목록 조회, 팀 검색 기능에 지역별 필터 기능 추가

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchServiceImpl.kt
@@ -19,8 +19,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class MatchServiceImpl(
     private val matchRepository: MatchRepository,
-
-    ) : MatchService {
+) : MatchService {
 
     @Transactional
     override fun postMatch(principal: UserPrincipal, request: PostMatchRequest): MatchStatusResponse {

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/Service/v1/TeamService.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/Service/v1/TeamService.kt
@@ -3,21 +3,23 @@ package com.teamsparta.tikitaka.domain.team.Service.v1
 import com.teamsparta.tikitaka.domain.team.dto.request.TeamRequest
 import com.teamsparta.tikitaka.domain.team.dto.response.PageResponse
 import com.teamsparta.tikitaka.domain.team.dto.response.TeamResponse
+import com.teamsparta.tikitaka.infra.security.UserPrincipal
 
 interface TeamService {
 
 
-    fun createTeam(request: TeamRequest): TeamResponse
+    fun createTeam(principal: UserPrincipal, request: TeamRequest): TeamResponse
 
-    fun updateTeam(request: TeamRequest, teamId: Long): TeamResponse
+    fun updateTeam(userId: Long, request: TeamRequest, teamId: Long): TeamResponse
 
-    fun deleteTeam(teamId: Long)
+    fun deleteTeam(userId: Long, teamId: Long)
 
-    fun getTeams(page: Int, size: Int, sortBy: String, direction: String): PageResponse<TeamResponse>
+    fun getTeams(region: String?, page: Int, size: Int, sortBy: String, direction: String): PageResponse<TeamResponse>
 
     fun getTeam(teamId: Long): TeamResponse
 
     fun searchTeamListByName(
+        region: String?,
         page: Int,
         size: Int,
         sortBy: String,

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/controller/v1/TeamController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/controller/v1/TeamController.kt
@@ -5,8 +5,10 @@ import com.teamsparta.tikitaka.domain.team.Service.v1.TeamService
 import com.teamsparta.tikitaka.domain.team.dto.request.TeamRequest
 import com.teamsparta.tikitaka.domain.team.dto.response.PageResponse
 import com.teamsparta.tikitaka.domain.team.dto.response.TeamResponse
+import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 @RequestMapping("/api/v1/teams")
@@ -16,6 +18,7 @@ class TeamController(
 ) {
     @GetMapping("/search")
     fun searchTeams(
+        region: String?,
         @RequestParam("page", defaultValue = "0") page: Int,
         @RequestParam("size", defaultValue = "10") size: Int,
         @RequestParam("sort_by", defaultValue = "createdAt") sortBy: String,
@@ -24,40 +27,44 @@ class TeamController(
 
         ): ResponseEntity<PageResponse<TeamResponse>> {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(teamService.searchTeamListByName(page, size, sortBy, direction, name))
+            .body(teamService.searchTeamListByName(region, page, size, sortBy, direction, name))
     }
 
     @PostMapping
     fun createTeam(
+        @AuthenticationPrincipal principal: UserPrincipal,
         @RequestBody request: TeamRequest
     ): ResponseEntity<TeamResponse> {
-        return ResponseEntity.status(HttpStatus.CREATED).body(teamService.createTeam(request))
+        return ResponseEntity.status(HttpStatus.CREATED).body(teamService.createTeam(principal, request))
     }
 
     @PutMapping("/{team-id}")
     fun updateTeam(
+        @AuthenticationPrincipal principal: UserPrincipal,
         @PathVariable("team-id") teamId: Long,
         @RequestBody request: TeamRequest
     ): ResponseEntity<TeamResponse> {
-        return ResponseEntity.status(HttpStatus.OK).body(teamService.updateTeam(request, teamId))
+        return ResponseEntity.status(HttpStatus.OK).body(teamService.updateTeam(principal.id, request, teamId))
     }
 
     @DeleteMapping("/{team-id}")
     fun deleteTeam(
+        @AuthenticationPrincipal principal: UserPrincipal,
         @PathVariable("team-id") teamId: Long
     ): ResponseEntity<Unit> {
-        teamService.deleteTeam(teamId)
+        teamService.deleteTeam(principal.id, teamId)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 
     @GetMapping
     fun getTeams(
+        region: String?,
         @RequestParam("page", defaultValue = "0") page: Int,
         @RequestParam("size", defaultValue = "10") size: Int,
         @RequestParam("sort_by", defaultValue = "created_at") sortBy: String,
         @RequestParam("sort_direction", defaultValue = "desc") direction: String
     ): ResponseEntity<PageResponse<TeamResponse>> {
-        return ResponseEntity.status(HttpStatus.OK).body(teamService.getTeams(page, size, sortBy, direction))
+        return ResponseEntity.status(HttpStatus.OK).body(teamService.getTeams(region, page, size, sortBy, direction))
     }
 
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/controller/v1/TeamController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/controller/v1/TeamController.kt
@@ -18,7 +18,7 @@ class TeamController(
 ) {
     @GetMapping("/search")
     fun searchTeams(
-        region: String?,
+        @RequestParam("region", required = false) region: String?,
         @RequestParam("page", defaultValue = "0") page: Int,
         @RequestParam("size", defaultValue = "10") size: Int,
         @RequestParam("sort_by", defaultValue = "createdAt") sortBy: String,
@@ -58,7 +58,7 @@ class TeamController(
 
     @GetMapping
     fun getTeams(
-        region: String?,
+        @RequestParam("region", required = false) region: String?,
         @RequestParam("page", defaultValue = "0") page: Int,
         @RequestParam("size", defaultValue = "10") size: Int,
         @RequestParam("sort_by", defaultValue = "created_at") sortBy: String,

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/request/TeamRequest.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/request/TeamRequest.kt
@@ -1,17 +1,20 @@
 package com.teamsparta.tikitaka.domain.team.dto.request
 
+import com.teamsparta.tikitaka.domain.common.Region
 import com.teamsparta.tikitaka.domain.team.model.Team
 
 data class TeamRequest(
     val name: String,
     val description: String,
-    val region: String
+    val region: Region
 )
 
 fun TeamRequest.toEntity(
+    userId: Long
 ): Team {
     return Team(
         name = this.name,
+        userId = userId,
         description = this.description,
         region = this.region
     )

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamResponse.kt
@@ -28,7 +28,7 @@ data class TeamResponse(
                 team.mannerScore,
                 team.attendanceScore,
                 team.recruitStatus,
-                team.region
+                team.region.name
             )
         }
     }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/Team.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/Team.kt
@@ -1,5 +1,6 @@
 package com.teamsparta.tikitaka.domain.team.model
 
+import com.teamsparta.tikitaka.domain.common.Region
 import com.teamsparta.tikitaka.domain.common.baseentity.BaseEntity
 import jakarta.persistence.*
 import org.hibernate.annotations.SQLRestriction
@@ -10,6 +11,9 @@ import org.hibernate.annotations.SQLRestriction
 class Team(
     @Column(name = "name", nullable = false)
     var name: String,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
 
     @Column(name = "description")
     var description: String,
@@ -32,8 +36,9 @@ class Team(
     @Column(name = "recruit_status", nullable = false)
     val recruitStatus: Boolean = false,
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "region", nullable = false)
-    var region: String
+    var region: Region
 
 ) : BaseEntity() {
     @Id
@@ -44,7 +49,7 @@ class Team(
     fun updateTeam(
         name: String,
         description: String,
-        region: String
+        region: Region
     ) {
         this.name = name
         this.description = description

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/CustomTeamRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/CustomTeamRepository.kt
@@ -5,8 +5,8 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface CustomTeamRepository {
-    fun findAllByPageable(pageable: Pageable): Page<Team>
+    fun findAllByPageable(pageable: Pageable, region: String?): Page<Team>
 
-    fun findByName(pageable: Pageable, name: String): Page<Team>
+    fun findByName(pageable: Pageable, name: String, region: String?): Page<Team>
 
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/CustomTeamRepositoryImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/CustomTeamRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.querydsl.core.types.Order
 import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.core.types.dsl.EntityPathBase
 import com.querydsl.core.types.dsl.PathBuilder
+import com.teamsparta.tikitaka.domain.common.Region
 import com.teamsparta.tikitaka.domain.team.model.QTeam
 import com.teamsparta.tikitaka.domain.team.model.Team
 import com.teamsparta.tikitaka.infra.querydsl.QueryDslSupport
@@ -20,9 +21,19 @@ class CustomTeamRepositoryImpl : CustomTeamRepository, QueryDslSupport() {
     private val team = QTeam.team
 
     override fun findAllByPageable(
-        pageable: Pageable
+        pageable: Pageable,
+        region: String?
     ): Page<Team> {
         val whereClause = BooleanBuilder()
+
+        if (region != null) {
+            val regionEnum = try {
+                Region.fromString(region)
+            } catch (e: IllegalArgumentException) {
+                throw IllegalArgumentException("Invalid region: $region")
+            }
+            whereClause.and(team.region.eq(regionEnum))
+        }
 
         val totalCount = queryFactory.select(team.count())
             .from(team)
@@ -39,9 +50,18 @@ class CustomTeamRepositoryImpl : CustomTeamRepository, QueryDslSupport() {
         return PageImpl(contents, pageable, totalCount)
     }
 
-    override fun findByName(pageable: Pageable, name: String): Page<Team> {
+    override fun findByName(pageable: Pageable, name: String, region: String?): Page<Team> {
         val whereClause = BooleanBuilder()
         whereClause.and(team.name.containsIgnoreCase(name))
+
+        if (region != null) {
+            val regionEnum = try {
+                Region.fromString(region)
+            } catch (e: IllegalArgumentException) {
+                throw IllegalArgumentException("Invalid region: $region")
+            }
+            whereClause.and(team.region.eq(regionEnum))
+        }
 
         val totalCount = queryFactory.select(team.count())
             .from(team)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/TeamRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/TeamRepository.kt
@@ -1,6 +1,8 @@
 package com.teamsparta.tikitaka.domain.team.repository
 
+
 import com.teamsparta.tikitaka.domain.team.model.Team
 import org.springframework.data.jpa.repository.JpaRepository
+
 
 interface TeamRepository : JpaRepository<Team, Long>, CustomTeamRepository

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/model/Users.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/model/Users.kt
@@ -1,7 +1,12 @@
 package com.teamsparta.tikitaka.domain.users.model
 
 import com.teamsparta.tikitaka.domain.common.exception.InvalidCredentialException
+import com.teamsparta.tikitaka.domain.team.model.teamMember.TeamRole
+import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import jakarta.persistence.*
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
 import java.time.LocalDateTime
 import java.util.regex.Pattern
 
@@ -64,5 +69,16 @@ class Users(
                 throw InvalidCredentialException("이메일은 영어 소문자와 숫자 및 @로 구성되어야합니다.")
             }
         }
+    }
+
+    fun updateUserRole(principal: UserPrincipal, role: TeamRole) {
+        val updatedUserPrincipal = UserPrincipal(
+            principal.id,
+            principal.name,
+            principal.authorities + SimpleGrantedAuthority("ROLE_${role}")
+        )
+        val authentication =
+            UsernamePasswordAuthenticationToken(updatedUserPrincipal, null, updatedUserPrincipal.authorities)
+        SecurityContextHolder.getContext().authentication = authentication
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/model/Users.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/model/Users.kt
@@ -18,15 +18,14 @@ class Users(
     var name: String,
 
     @Column(name = "team_status")
-    val teamStatus: Boolean = false,
+    var teamStatus: Boolean = false,
 
     @Column(name = "created_at", nullable = false)
     var createdAt: LocalDateTime = LocalDateTime.now(),
 
     @Column(name = "deleted_at", nullable = true)
     var deletedAt: LocalDateTime? = null,
-)
-{
+) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
@@ -51,7 +50,11 @@ class Users(
             if (newPassword.length !in 8..15) {
                 throw InvalidCredentialException("비밀번호는 최소 8자 이상, 15자 이하여야만 합니다.")
             }
-            if (!Pattern.matches("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@\$!%*?&])[A-Za-z\\d@\$!%*?&]{8,15}$", newPassword)) {
+            if (!Pattern.matches(
+                    "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@\$!%*?&])[A-Za-z\\d@\$!%*?&]{8,15}$",
+                    newPassword
+                )
+            ) {
                 throw InvalidCredentialException("비밀번호는 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자가 포함되어야 합니다.")
             }
         }

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/UserPrincipal.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/UserPrincipal.kt
@@ -13,5 +13,5 @@ data class UserPrincipal(
         id: Long,
         name: String,
         role: TeamRole?,
-    ) : this(id, name, if (role == null) emptySet<GrantedAuthority>() else setOf(SimpleGrantedAuthority("ROLE_$role")))
+    ) : this(id, name, role?.let { setOf(SimpleGrantedAuthority("ROLE_$it")) } ?: emptySet<GrantedAuthority>())
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #54 

## 📝작업 내용

> 팀 생성 시 
- TeamMember 내 role Leader 부여
- 유저 teamStatus True로 변경
> 팀 수정, 삭제
- 해당 팀의 leader권한이 있는 사람만 접근 가능
> 팀 목록 조회, 팀 검색
-  지역별로 필터 기능 추가





## ✏️ 테스트 여부
- [ ] 테스트완료

