### PR TITLE
♻️ #65 - #67 - Matchapplication Version1 Refactoring, 오류 체크 및 예외 처리 추가

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/common/exception/AnyThingNotFoundException.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/common/exception/AnyThingNotFoundException.kt
@@ -1,4 +1,0 @@
-package com.teamsparta.tikitaka.domain.common.exception
-
-class AnyThingNotFoundException (message: String?) : RuntimeException(message) {
-}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/common/exception/GlobalExceptionHandler.kt
@@ -59,4 +59,11 @@ class GlobalExceptionHandler {
             .status(HttpStatus.BAD_REQUEST)
             .body(ErrorResponse(message = e.message))
     }
+
+    @ExceptionHandler(IllegalStateException::class)
+    fun handleIllegalArgumentException(e: IllegalStateException): ResponseEntity<ErrorResponse> {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(message = e.message))
+    }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
@@ -29,11 +29,12 @@ class MatchApplicationController2(
     }
 
     @DeleteMapping("/{match-id}/match-applications/{application-id}")
-    fun deleteMatchApplication(
+    fun cancelMatchApplication(
         @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable(name = "match-id") matchId: Long,
         @PathVariable(name = "application-id") applicationId: Long,
     ): ResponseEntity<Unit> {
-        matchApplicationService.deleteMatchApplication(principal, applicationId)
+        matchApplicationService.cancelMatchApplication(principal, matchId, applicationId)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
@@ -1,7 +1,6 @@
 package com.teamsparta.tikitaka.domain.match.controller.v2.matchapplication2
 
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.*
-import com.teamsparta.tikitaka.domain.match.service.v1.matchapplication.MatchApplicationService
 import com.teamsparta.tikitaka.domain.match.service.v2.matchapplication2.MatchApplicationService2
 import com.teamsparta.tikitaka.domain.team.model.teammember.TeamRole
 import com.teamsparta.tikitaka.infra.security.CustomPreAuthorize
@@ -41,11 +40,12 @@ class MatchApplicationController2(
     @PatchMapping("/{match-id}/match-applications/{application-id}")
     fun replyMatchApplication(
         @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable(name = "match-id") matchId: Long,
         @PathVariable(name = "application-id") applicationId: Long,
         @RequestBody request: ReplyApplicationRequest
     ): ResponseEntity<MatchApplicationResponse> {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(matchApplicationService.replyMatchApplication(principal.id, applicationId, request))
+            .body(matchApplicationService.replyMatchApplication(principal.id, matchId, applicationId, request))
     }
 
     @GetMapping("/match-applications/my-applications")

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/matchapplication/MatchApplicationRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/matchapplication/MatchApplicationRepository.kt
@@ -1,8 +1,10 @@
 package com.teamsparta.tikitaka.domain.match.repository.matchapplication
 
+import com.teamsparta.tikitaka.domain.match.model.matchapplication.ApproveStatus
 import com.teamsparta.tikitaka.domain.match.model.matchapplication.MatchApplication
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MatchApplicationRepository : JpaRepository<MatchApplication, Long>, CustomMatchApplicationRepository {
     fun findByApplyTeamIdAndMatchPostId(applyTeamId: Long, matchPostId: Long): List<MatchApplication>
+    fun findByMatchPostIdAndApproveStatus(matchPostId: Long, approveStatus: ApproveStatus): List<MatchApplication>
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/matchapplication/MatchApplicationRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/matchapplication/MatchApplicationRepository.kt
@@ -3,4 +3,6 @@ package com.teamsparta.tikitaka.domain.match.repository.matchapplication
 import com.teamsparta.tikitaka.domain.match.model.matchapplication.MatchApplication
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface MatchApplicationRepository : JpaRepository<MatchApplication, Long>, CustomMatchApplicationRepository
+interface MatchApplicationRepository : JpaRepository<MatchApplication, Long>, CustomMatchApplicationRepository {
+    fun findByApplyTeamIdAndMatchPostId(applyTeamId: Long, matchPostId: Long): List<MatchApplication>
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchServiceImpl.kt
@@ -47,9 +47,6 @@ class MatchServiceImpl(
         val team = teamRepository.findByIdOrNull(request.teamId)
             ?: throw ModelNotFoundException("team", request.teamId)
 
-        team.updateTeamStatus()
-
-
         return MatchResponse.from(match)
     }
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/MatchServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/MatchServiceImpl2.kt
@@ -47,9 +47,6 @@ class MatchServiceImpl2(
         val team = teamRepository.findByIdOrNull(request.teamId)
             ?: throw ModelNotFoundException("team", request.teamId)
 
-        team.updateTeamStatus()
-
-
         return MatchResponse.from(match)
     }
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
@@ -8,6 +8,7 @@ interface MatchApplicationService2 {
 
     fun replyMatchApplication(
         userId: Long,
+        matchId: Long,
         applicationId: Long,
         request: ReplyApplicationRequest
     ): MatchApplicationResponse

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
@@ -16,7 +16,7 @@ interface MatchApplicationService2 {
 
     fun getMyApplications(request: MyApplicationRequest): List<MyApplicationsResponse>
 
-    fun deleteMatchApplication(
-        principal: UserPrincipal, applicationId: Long
+    fun cancelMatchApplication(
+        principal: UserPrincipal, matchId: Long, applicationId: Long
     )
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
@@ -92,6 +92,7 @@ class MatchApplicationServiceImpl2
             rejectOtherApplications(matchId, applicationId)
         }
 
+        matchPost.matchStatus = true
         return MatchApplicationResponse.from(matchApply)
     }
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
@@ -28,20 +28,32 @@ class MatchApplicationServiceImpl2
     @Transactional
     override fun applyMatch(userId: Long, request: CreateApplicationRequest, matchId: Long): MatchApplicationResponse {
         usersRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User", userId)
-
-        val matchPost = matchRepository.findByIdOrNull(matchId) ?: throw ModelNotFoundException("match", matchId)
+        val matchPost = matchRepository.findByIdOrNull(matchId) ?: throw ModelNotFoundException("Match", matchId)
         val (teamId) = request
 
-        val matchDate = matchPost.matchDate.toLocalDate()
+        if (matchPost.matchStatus) {
+            throw IllegalStateException("This match is already closed for applications.")
+        }
 
+        if (matchPost.teamId == teamId) {
+            throw IllegalArgumentException("Team cannot apply to a match posted by itself.")
+        }
+
+        val sameTeamApplications = matchApplicationRepository.findByApplyTeamIdAndMatchPostId(teamId, matchId)
+        if (sameTeamApplications.any { it.approveStatus == ApproveStatus.WAITING || it.approveStatus == ApproveStatus.APPROVE }) {
+            throw TeamAlreadyAppliedException("You cannot reapply to a match that already has an active or approved application from your team.")
+        }
+
+        val matchDate = matchPost.matchDate.toLocalDate()
         val existingApplications = matchApplicationRepository.findByTeamIdAndMatchDate(teamId, matchDate)
         if (existingApplications.any { it.approveStatus == ApproveStatus.WAITING || it.approveStatus == ApproveStatus.APPROVE }) {
             throw TeamAlreadyAppliedException("Your team already has a pending or approved application for the same match date.")
         }
 
-        return matchApplicationRepository.save(MatchApplication.of(matchPost, teamId, userId))
-            .let { MatchApplicationResponse.from(it) }
+        val newApplication = MatchApplication.of(matchPost, teamId, userId)
+        return MatchApplicationResponse.from(matchApplicationRepository.save(newApplication))
     }
+
 
     @Transactional
     override fun deleteMatchApplication(principal: UserPrincipal, applicationId: Long) {

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/Team.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/Team.kt
@@ -55,10 +55,5 @@ class Team(
         this.description = description
         this.region = region
     }
-
-    fun updateTeamStatus() {
-        this.recruitStatus = true
-    }
-
 }
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersServiceImpl.kt
@@ -1,6 +1,5 @@
 package com.teamsparta.tikitaka.domain.users.service.v1
 
-import com.teamsparta.tikitaka.domain.common.exception.AnyThingNotFoundException
 import com.teamsparta.tikitaka.domain.common.exception.InvalidCredentialException
 import com.teamsparta.tikitaka.domain.common.exception.ModelNotFoundException
 import com.teamsparta.tikitaka.domain.common.util.RedisUtils
@@ -10,7 +9,6 @@ import com.teamsparta.tikitaka.domain.users.model.Users
 import com.teamsparta.tikitaka.domain.users.repository.UsersRepository
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import com.teamsparta.tikitaka.infra.security.jwt.JwtPlugin
-import org.apache.catalina.User
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
@@ -93,7 +91,8 @@ class UsersServiceImpl(
     }
 
     override fun updateName(request: NameRequest, userPrincipal: UserPrincipal): NameResponse {
-        val user = usersRepository.findByIdOrNull(userPrincipal.id) ?: throw ModelNotFoundException("Users",userPrincipal.id)
+        val user =
+            usersRepository.findByIdOrNull(userPrincipal.id) ?: throw ModelNotFoundException("Users", userPrincipal.id)
         if (user.id != userPrincipal.id) {
             throw InvalidCredentialException("인증되지 않은 사용자입니다")
         }
@@ -106,13 +105,14 @@ class UsersServiceImpl(
     }
 
     override fun updatePassword(request: PasswordRequest, userPrincipal: UserPrincipal): PasswordResponse {
-        val user = usersRepository.findByIdOrNull(userPrincipal.id) ?: throw ModelNotFoundException("Users",userPrincipal.id)
+        val user =
+            usersRepository.findByIdOrNull(userPrincipal.id) ?: throw ModelNotFoundException("Users", userPrincipal.id)
         if (user.id != userPrincipal.id) {
             throw InvalidCredentialException("인증되지 않은 사용자입니다")
         }
-            if (passwordEncoder.matches(request.password, user.password)) {
-                throw IllegalArgumentException("기존에 사용한 패스워드입니다")
-            }
+        if (passwordEncoder.matches(request.password, user.password)) {
+            throw IllegalArgumentException("기존에 사용한 패스워드입니다")
+        }
         Users.validatePassword(request.password)
         user.updatePassword(passwordEncoder.encode(request.password))
         usersRepository.save(user)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #65 #66 #67 

## 📝작업 내용

> - Application Post시, 한 팀이 하나의 매치에 여러번 신청할 수 없도록 설정 추가
> - Cancel시, SoftDelete 되지 않도록 설정 변경
> - Cancel시, 이미 취소된 신청 내역은 취소처리 할 수 없도록 설정
> - Application의 ApproveStatus가 "REJECT" 또는 "APPROVE" 경우 취소 불가능
> - 하나의 Application에 대해 승인 시, Status가 "WAITING"인 다른 Application을 "REJECT로 변경하면서 동시에, MatchStatus를 True로 변경
> - 예외처리 공통 처리 (MatchId, UserId, ApplicationId를 찾고, 예외처리 하는 부분)
> - 비즈니스 로직을 분리하여, 서비스 레이어의 코드의 가독성을 높이는 작업 진행

## 💬리뷰 요구사항(선택)

> 저도 작업을 하다보니, 이리저리 엮인 부분이 있어 미처 생각하지 못한 부분들이 있을 것 같아, 꼼꼼하게 같이 체크해주시면 감사하겠습니다.
추가로 Method가 세부적으로 나뉘어지지 않은 부분들이 있어서, 이 부분은 조금 더 고려해보도록 하겠습니다.

## ✏️ 테스트 여부
- [x] 테스트완료
