### PR TITLE
✨ #70 - updateRecruitmentPost Method 생성

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
@@ -29,7 +29,7 @@ class MatchApplicationServiceImpl2(
 
     @Transactional
     override fun applyMatch(userId: Long, request: CreateApplicationRequest, matchId: Long): MatchApplicationResponse {
-        val user = findUserById(userId)
+        findUserById(userId)
         val matchPost = findMatchById(matchId)
         val (teamId) = request
         validateMatchAvailability(matchPost, teamId)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/controller/v2/LeaderRecruitmentController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/controller/v2/LeaderRecruitmentController.kt
@@ -1,0 +1,35 @@
+package com.teamsparta.tikitaka.domain.recruitment.controller.v2
+
+import com.teamsparta.tikitaka.domain.recruitment.dto.PostRecruitmentRequest
+import com.teamsparta.tikitaka.domain.recruitment.dto.PostRecruitmentResponse
+import com.teamsparta.tikitaka.domain.recruitment.service.v2.LeaderRecruitmentService
+import com.teamsparta.tikitaka.domain.team.model.teammember.TeamRole
+import com.teamsparta.tikitaka.infra.security.CustomPreAuthorize
+import com.teamsparta.tikitaka.infra.security.UserPrincipal
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v2/leader/recruitments")
+class LeaderRecruitmentController(
+    private val preAuthorize: CustomPreAuthorize,
+    private val leaderRecruitmentService: LeaderRecruitmentService,
+) {
+
+    @PostMapping()
+    fun postRecruitment(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @RequestBody request: PostRecruitmentRequest
+    ): ResponseEntity<PostRecruitmentResponse> {
+        return preAuthorize.hasAnyRole(principal, setOf(TeamRole.LEADER)) {
+            ResponseEntity.status(HttpStatus.OK)
+                .body(leaderRecruitmentService.postRecruitment(principal, request))
+        }
+    }
+
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/controller/v2/LeaderRecruitmentController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/controller/v2/LeaderRecruitmentController.kt
@@ -37,7 +37,9 @@ class LeaderRecruitmentController(
         @PathVariable(name = "recruitment-id") recruitmentId: Long,
         @RequestBody request: UpdateRecruitmentRequest
     ): ResponseEntity<RecruitmentResponse> {
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(leaderRecruitmentService.updateRecruitmentPost(principal.id, recruitmentId, request))
+        return preAuthorize.hasAnyRole(principal, setOf(TeamRole.LEADER)) {
+            ResponseEntity.status(HttpStatus.OK)
+                .body(leaderRecruitmentService.updateRecruitmentPost(principal.id, recruitmentId, request))
+        }
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/controller/v2/LeaderRecruitmentController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/controller/v2/LeaderRecruitmentController.kt
@@ -2,6 +2,8 @@ package com.teamsparta.tikitaka.domain.recruitment.controller.v2
 
 import com.teamsparta.tikitaka.domain.recruitment.dto.PostRecruitmentRequest
 import com.teamsparta.tikitaka.domain.recruitment.dto.PostRecruitmentResponse
+import com.teamsparta.tikitaka.domain.recruitment.dto.RecruitmentResponse
+import com.teamsparta.tikitaka.domain.recruitment.dto.UpdateRecruitmentRequest
 import com.teamsparta.tikitaka.domain.recruitment.service.v2.LeaderRecruitmentService
 import com.teamsparta.tikitaka.domain.team.model.teammember.TeamRole
 import com.teamsparta.tikitaka.infra.security.CustomPreAuthorize
@@ -9,10 +11,7 @@ import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v2/leader/recruitments")
@@ -32,4 +31,13 @@ class LeaderRecruitmentController(
         }
     }
 
+    @PutMapping("{recruitment-id}")
+    fun updateRecruitmentPost(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable(name = "recruitment-id") recruitmentId: Long,
+        @RequestBody request: UpdateRecruitmentRequest
+    ): ResponseEntity<RecruitmentResponse> {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(leaderRecruitmentService.updateRecruitmentPost(principal.id, recruitmentId, request))
+    }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/PostRecruitmentRequest.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/PostRecruitmentRequest.kt
@@ -1,11 +1,9 @@
 package com.teamsparta.tikitaka.domain.recruitment.dto
 
-import com.teamsparta.tikitaka.domain.recruitment.model.RecruitType
-
 data class PostRecruitmentRequest(
     val userId: Long,
     val teamId: Long,
-    val recruitType: RecruitType,
+    val recruitType: String,
     val quantity: Int,
     val content: String,
 )

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/PostRecruitmentRequest.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/PostRecruitmentRequest.kt
@@ -1,0 +1,11 @@
+package com.teamsparta.tikitaka.domain.recruitment.dto
+
+import com.teamsparta.tikitaka.domain.recruitment.model.RecruitType
+
+data class PostRecruitmentRequest(
+    val userId: Long,
+    val teamId: Long,
+    val recruitType: RecruitType,
+    val quantity: Int,
+    val content: String,
+)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/PostRecruitmentResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/PostRecruitmentResponse.kt
@@ -1,0 +1,19 @@
+package com.teamsparta.tikitaka.domain.recruitment.dto
+
+import com.teamsparta.tikitaka.domain.recruitment.model.RecruitType
+import com.teamsparta.tikitaka.domain.recruitment.model.Recruitment
+
+data class PostRecruitmentResponse(
+    val recruitmentId: Long,
+    val recruitType: RecruitType,
+    val closingStatus: Boolean,
+) {
+
+    companion object {
+        fun from(recruitment: Recruitment) = PostRecruitmentResponse(
+            recruitmentId = recruitment.id!!,
+            recruitType = recruitment.recruitType,
+            closingStatus = false,
+        )
+    }
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/RecruitmentDto.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/RecruitmentDto.kt
@@ -1,4 +1,0 @@
-package com.teamsparta.tikitaka.domain.recruitment.dto
-
-class RecruitmentDto {
-}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/RecruitmentResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/RecruitmentResponse.kt
@@ -1,0 +1,24 @@
+package com.teamsparta.tikitaka.domain.recruitment.dto
+
+import com.teamsparta.tikitaka.domain.recruitment.model.Recruitment
+
+data class RecruitmentResponse(
+    val recruitmentId: Long,
+    val userId: Long,
+    val teamId: Long,
+    val recruitType: String,
+    val quantity: Int,
+    val content: String
+) {
+
+    companion object {
+        fun from(recruitment: Recruitment) = RecruitmentResponse(
+            recruitmentId = recruitment.id!!,
+            userId = recruitment.userId,
+            teamId = recruitment.teamId,
+            recruitType = recruitment.recruitType.toString(),
+            quantity = recruitment.quantity,
+            content = recruitment.content
+        )
+    }
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/RecruitmentResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/RecruitmentResponse.kt
@@ -3,7 +3,6 @@ package com.teamsparta.tikitaka.domain.recruitment.dto
 import com.teamsparta.tikitaka.domain.recruitment.model.Recruitment
 
 data class RecruitmentResponse(
-    val recruitmentId: Long,
     val userId: Long,
     val teamId: Long,
     val recruitType: String,
@@ -13,7 +12,6 @@ data class RecruitmentResponse(
 
     companion object {
         fun from(recruitment: Recruitment) = RecruitmentResponse(
-            recruitmentId = recruitment.id!!,
             userId = recruitment.userId,
             teamId = recruitment.teamId,
             recruitType = recruitment.recruitType.toString(),

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/UpdateRecruitmentRequest.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/dto/UpdateRecruitmentRequest.kt
@@ -1,0 +1,7 @@
+package com.teamsparta.tikitaka.domain.recruitment.dto
+
+data class UpdateRecruitmentRequest(
+    val recruitType: String,
+    val quantity: Int,
+    val content: String,
+)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/model/RecruitType.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/model/RecruitType.kt
@@ -9,7 +9,7 @@ enum class RecruitType {
             return try {
                 valueOf(value.uppercase())
             } catch (e: IllegalArgumentException) {
-                throw IllegalArgumentException("Invalid sort criteria: $value")
+                throw IllegalArgumentException("Invalid RecruitType: $value")
             }
         }
     }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/model/Recruitment.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/model/Recruitment.kt
@@ -1,6 +1,7 @@
 package com.teamsparta.tikitaka.domain.recruitment.model
 
 import com.teamsparta.tikitaka.domain.common.baseentity.BaseEntity
+import com.teamsparta.tikitaka.domain.recruitment.dto.UpdateRecruitmentRequest
 import jakarta.persistence.*
 import org.hibernate.annotations.SQLRestriction
 
@@ -16,7 +17,7 @@ class Recruitment(
     val userId: Long,
 
     @Enumerated(EnumType.STRING)
-    val recruitType: RecruitType,
+    var recruitType: RecruitType,
 
     @Column(name = "quantity", nullable = false)
     var quantity: Int,
@@ -32,7 +33,13 @@ class Recruitment(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
 
-    //todo : updateMatch
+    fun updateRecruitment(
+        request: UpdateRecruitmentRequest,
+    ) {
+        this.content = request.content
+        this.quantity = request.quantity
+        this.recruitType = RecruitType.fromString(request.recruitType)
+    }
 
     companion object {
         fun of(

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/model/Recruitment.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/model/Recruitment.kt
@@ -31,4 +31,28 @@ class Recruitment(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
+
+    //todo : updateMatch
+
+    companion object {
+        fun of(
+            teamId: Long,
+            userId: Long,
+            recruitType: RecruitType,
+            quantity: Int,
+            content: String,
+            closingStatus: Boolean,
+        ): Recruitment {
+            return Recruitment(
+                teamId = teamId,
+                userId = userId,
+                recruitType = recruitType,
+                quantity = quantity,
+                content = content,
+                closingStatus = closingStatus,
+            )
+        }
+    }
+
+
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/model/Recruitment.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/model/Recruitment.kt
@@ -38,7 +38,7 @@ class Recruitment(
         fun of(
             teamId: Long,
             userId: Long,
-            recruitType: RecruitType,
+            recruitType: String,
             quantity: Int,
             content: String,
             closingStatus: Boolean,
@@ -46,7 +46,7 @@ class Recruitment(
             return Recruitment(
                 teamId = teamId,
                 userId = userId,
-                recruitType = recruitType,
+                recruitType = RecruitType.fromString(recruitType),
                 quantity = quantity,
                 content = content,
                 closingStatus = closingStatus,

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/repository/RecruitmentRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/repository/RecruitmentRepository.kt
@@ -1,4 +1,8 @@
 package com.teamsparta.tikitaka.domain.recruitment.repository
 
-class RecruitmentRepository {
-}
+import com.teamsparta.tikitaka.domain.recruitment.model.Recruitment
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RecruitmentRepository : JpaRepository<Recruitment, Long>

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/service/v2/LeaderRecruitmentService.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/service/v2/LeaderRecruitmentService.kt
@@ -2,8 +2,11 @@ package com.teamsparta.tikitaka.domain.recruitment.service.v2
 
 import com.teamsparta.tikitaka.domain.recruitment.dto.PostRecruitmentRequest
 import com.teamsparta.tikitaka.domain.recruitment.dto.PostRecruitmentResponse
+import com.teamsparta.tikitaka.domain.recruitment.dto.RecruitmentResponse
+import com.teamsparta.tikitaka.domain.recruitment.dto.UpdateRecruitmentRequest
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 
 interface LeaderRecruitmentService {
     fun postRecruitment(principal: UserPrincipal, request: PostRecruitmentRequest): PostRecruitmentResponse
+    fun updateRecruitmentPost(userId: Long, recruitmentId: Long, request: UpdateRecruitmentRequest): RecruitmentResponse
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/service/v2/LeaderRecruitmentService.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/service/v2/LeaderRecruitmentService.kt
@@ -1,0 +1,9 @@
+package com.teamsparta.tikitaka.domain.recruitment.service.v2
+
+import com.teamsparta.tikitaka.domain.recruitment.dto.PostRecruitmentRequest
+import com.teamsparta.tikitaka.domain.recruitment.dto.PostRecruitmentResponse
+import com.teamsparta.tikitaka.infra.security.UserPrincipal
+
+interface LeaderRecruitmentService {
+    fun postRecruitment(principal: UserPrincipal, request: PostRecruitmentRequest): PostRecruitmentResponse
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/service/v2/LeaderRecruitmentServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/service/v2/LeaderRecruitmentServiceImpl.kt
@@ -1,0 +1,42 @@
+package com.teamsparta.tikitaka.domain.recruitment.service.v2
+
+import com.teamsparta.tikitaka.domain.common.exception.ModelNotFoundException
+import com.teamsparta.tikitaka.domain.recruitment.dto.PostRecruitmentRequest
+import com.teamsparta.tikitaka.domain.recruitment.dto.PostRecruitmentResponse
+import com.teamsparta.tikitaka.domain.recruitment.model.Recruitment
+import com.teamsparta.tikitaka.domain.recruitment.repository.RecruitmentRepository
+import com.teamsparta.tikitaka.domain.team.model.teammember.TeamRole
+import com.teamsparta.tikitaka.domain.team.repository.teamMember.TeamMemberRepository
+import com.teamsparta.tikitaka.infra.security.UserPrincipal
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class LeaderRecuritmentServiceImpl(
+    private val teamMemberRepository: TeamMemberRepository,
+    private val recruitmentRepository: RecruitmentRepository,
+) : LeaderRecruitmentService {
+    override fun postRecruitment(principal: UserPrincipal, request: PostRecruitmentRequest): PostRecruitmentResponse {
+
+        val leader = teamMemberRepository.findByIdOrNull(principal.id)
+            ?: throw ModelNotFoundException("leader", principal.id)
+
+        if (leader.teamRole != TeamRole.LEADER) {
+            throw IllegalArgumentException("Only the current leader can reassign roles")
+        }
+
+        val recruitment = recruitmentRepository.save(
+            Recruitment.of(
+                teamId = request.teamId,
+                userId = request.userId,
+                recruitType = request.recruitType,
+                quantity = request.quantity,
+                content = request.content,
+                closingStatus = false,
+            )
+        )
+
+        return PostRecruitmentResponse.from(recruitment)
+
+    }
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/service/v2/LeaderRecruitmentServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/recruitment/service/v2/LeaderRecruitmentServiceImpl.kt
@@ -11,6 +11,7 @@ import com.teamsparta.tikitaka.domain.recruitment.repository.RecruitmentReposito
 import com.teamsparta.tikitaka.domain.team.model.teammember.TeamRole
 import com.teamsparta.tikitaka.domain.team.repository.teamMember.TeamMemberRepository
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
+import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
@@ -42,6 +43,7 @@ class LeaderRecruitmentServiceImpl(
         return PostRecruitmentResponse.from(recruitment)
     }
 
+    @Transactional
     override fun updateRecruitmentPost(
         userId: Long,
         recruitmentId: Long,
@@ -51,7 +53,6 @@ class LeaderRecruitmentServiceImpl(
             "recruitment",
             recruitmentId
         )
-        val (recruitType, quantity, content) = request
 
         if (recruitmentPost.userId != userId) {
             throw AccessDeniedException("You can only modify recruitment posted by your own team.")
@@ -59,15 +60,9 @@ class LeaderRecruitmentServiceImpl(
         if (recruitmentPost.closingStatus) {
             throw IllegalStateException("This recruitment is already closed.")
         }
-        val revisedRecruitment =
-            Recruitment.of(
-                teamId = recruitmentPost.teamId,
-                userId = recruitmentPost.userId,
-                recruitType = recruitType,
-                quantity = quantity,
-                content = content,
-                closingStatus = false
-            )
-        return RecruitmentResponse.from(revisedRecruitment)
+        recruitmentPost.updateRecruitment(
+            request
+        )
+        return RecruitmentResponse.from(recruitmentPost)
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #70 

## 📝작업 내용

> RecruitmentId를 통해 Recruitment Post 여부 검증
> 현재 사용자가 글을 작성한 사람이 맞는지 (현재 사용자가 구인 공고를 작성한 팀의 리더가 맞는지) 추가 검증 진행
> 수정하려는 Recruitment의 ClosingStatus가 True일 시(공고 마감 시) 수정 불가능

## 💬리뷰 요구사항

> 한 번에 너무 많은 API를 PR에 반영하면, 리뷰가 잘 되지 않는 것 같아서 하나의 API만 있는 점 참고부탁드립니다!
> #68 Branch 일부를 함께 활용 (Conflict 방지 차원)하였습니다.
> 추가적으로 SupaBase 내부에 테스트 진행을 위해, Recruitment 테이블을 생성하였습니다.

## ✏️ 테스트 여부
- [x] 테스트완료
