### PR TITLE
:recycle: #73 - Team, Page Response DTO 수정 및 각 로직에 적용

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/PageResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/PageResponse.kt
@@ -5,5 +5,6 @@ import java.io.Serializable
 data class PageResponse<T>(
     val content: List<T>,
     val pageNumber: Int,
-    val pageSize: Int
+    val pageSize: Int,
+    val totalPages: Int
 ) : Serializable

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamResponse.kt
@@ -1,6 +1,7 @@
 package com.teamsparta.tikitaka.domain.team.dto.response
 
 import com.teamsparta.tikitaka.domain.team.model.Team
+import java.time.LocalDateTime
 
 data class TeamResponse(
     val id: Long,
@@ -12,7 +13,8 @@ data class TeamResponse(
     val mannerScore: Int,
     val attendanceScore: Int,
     val recruitStatus: Boolean,
-    val region: String
+    val region: String,
+    val createAt: LocalDateTime
 ) {
     companion object {
         fun from(
@@ -28,7 +30,8 @@ data class TeamResponse(
                 team.mannerScore,
                 team.attendanceScore,
                 team.recruitStatus,
-                team.region.name
+                team.region.name,
+                team.createdAt
             )
         }
     }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v1/TeamServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v1/TeamServiceImpl.kt
@@ -43,7 +43,8 @@ class TeamServiceImpl(
         return PageResponse(
             pageContent.content.map { TeamResponse.from(it) },
             page,
-            size
+            size,
+            pageContent.totalPages
         )
     }
 
@@ -114,7 +115,8 @@ class TeamServiceImpl(
         return PageResponse(
             pageContent.content.map { TeamResponse.from(it) },
             page,
-            size
+            size,
+            pageContent.totalPages
         )
     }
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v2/TeamServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v2/TeamServiceImpl2.kt
@@ -43,7 +43,8 @@ class TeamServiceImpl2(
         return PageResponse(
             pageContent.content.map { TeamResponse.from(it) },
             page,
-            size
+            size,
+            pageContent.totalPages
         )
     }
 
@@ -114,7 +115,8 @@ class TeamServiceImpl2(
         return PageResponse(
             pageContent.content.map { TeamResponse.from(it) },
             page,
-            size
+            size,
+            pageContent.totalPages
         )
     }
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/config/WebConfig.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/config/WebConfig.kt
@@ -1,0 +1,24 @@
+package com.teamsparta.tikitaka.infra.security.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig {
+    @Bean
+    fun corsConfigurer(): WebMvcConfigurer {
+        return object : WebMvcConfigurer {
+            override fun addCorsMappings(registry: CorsRegistry) {
+                registry.addMapping("/**")
+                    .allowedOrigins("http://localhost:3000")
+                    .allowedOrigins("http://localhost:5173")
+                    .allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS")
+                    .allowedHeaders("*")
+                    .exposedHeaders("Authorization", "RefreshToken")
+                    .allowCredentials(true)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #73 

## 📝작업 내용

> PageResponse에 totalPage를 넘겨주지 않음으로 인해 발생하는 문제 해결
TeamResponse에 createdAt을 추가함으로 팀 창단일 보여주기

## ✏️ 테스트 여부
- [ ] 테스트완료

