### PR TITLE
♻️ #87 - 기존 RequestDto를 통해 TeamId 받는 방식을 Service에서 처리할 수 있도록 변경

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v1/matchapplication/MatchApplicationController.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v1/matchapplication/MatchApplicationController.kt
@@ -1,6 +1,8 @@
 package com.teamsparta.tikitaka.domain.match.controller.v1.matchapplication
 
-import com.teamsparta.tikitaka.domain.match.dto.matchapplication.*
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MyApplicationsResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.ReplyApplicationRequest
 import com.teamsparta.tikitaka.domain.match.service.v1.matchapplication.MatchApplicationService
 import com.teamsparta.tikitaka.domain.team.model.teammember.TeamRole
 import com.teamsparta.tikitaka.infra.security.CustomPreAuthorize
@@ -20,11 +22,10 @@ class MatchApplicationController(
     fun applyMatch(
         @AuthenticationPrincipal principal: UserPrincipal,
         @PathVariable(name = "match-id") matchId: Long,
-        @RequestBody request: CreateApplicationRequest
     ): ResponseEntity<MatchApplicationResponse> {
         return preAuthorize.hasAnyRole(principal, setOf(TeamRole.LEADER, TeamRole.SUB_LEADER)) {
             ResponseEntity.status(HttpStatus.CREATED)
-                .body(matchApplicationService.applyMatch(principal.id, request, matchId))
+                .body(matchApplicationService.applyMatch(principal.id, matchId))
         }
     }
 
@@ -49,8 +50,8 @@ class MatchApplicationController(
 
     @GetMapping("/match-applications/my-applications")
     fun getMyApplications(
-        @RequestBody request: MyApplicationRequest
+        @AuthenticationPrincipal principal: UserPrincipal,
     ): ResponseEntity<List<MyApplicationsResponse>> {
-        return ResponseEntity.ok(matchApplicationService.getMyApplications(request))
+        return ResponseEntity.ok(matchApplicationService.getMyApplications(principal.id))
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
@@ -1,6 +1,8 @@
 package com.teamsparta.tikitaka.domain.match.controller.v2.matchapplication2
 
-import com.teamsparta.tikitaka.domain.match.dto.matchapplication.*
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MyApplicationsResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.ReplyApplicationRequest
 import com.teamsparta.tikitaka.domain.match.service.v2.matchapplication2.MatchApplicationService2
 import com.teamsparta.tikitaka.domain.team.model.teammember.TeamRole
 import com.teamsparta.tikitaka.infra.security.CustomPreAuthorize
@@ -20,11 +22,10 @@ class MatchApplicationController2(
     fun applyMatch(
         @AuthenticationPrincipal principal: UserPrincipal,
         @PathVariable(name = "match-id") matchId: Long,
-        @RequestBody request: CreateApplicationRequest
     ): ResponseEntity<MatchApplicationResponse> {
         return preAuthorize.hasAnyRole(principal, setOf(TeamRole.LEADER, TeamRole.SUB_LEADER)) {
             ResponseEntity.status(HttpStatus.CREATED)
-                .body(matchApplicationService.applyMatch(principal.id, request, matchId))
+                .body(matchApplicationService.applyMatch(principal.id, matchId))
         }
     }
 
@@ -51,8 +52,8 @@ class MatchApplicationController2(
 
     @GetMapping("/match-applications/my-applications")
     fun getMyApplications(
-        @RequestBody request: MyApplicationRequest
+        @AuthenticationPrincipal principal: UserPrincipal,
     ): ResponseEntity<List<MyApplicationsResponse>> {
-        return ResponseEntity.ok(matchApplicationService.getMyApplications(request))
+        return ResponseEntity.ok(matchApplicationService.getMyApplications(principal.id))
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/PostMatchRequest.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/PostMatchRequest.kt
@@ -9,5 +9,4 @@ data class PostMatchRequest(
     val region: Region,
     val location: String,
     val content: String,
-    val teamId: Long,
 )

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/matchapplication/CreateApplicationRequest.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/matchapplication/CreateApplicationRequest.kt
@@ -1,5 +1,0 @@
-package com.teamsparta.tikitaka.domain.match.dto.matchapplication
-
-data class CreateApplicationRequest(
-    val teamId: Long
-)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/matchapplication/MyApplicationRequest.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/matchapplication/MyApplicationRequest.kt
@@ -1,5 +1,0 @@
-package com.teamsparta.tikitaka.domain.match.dto.matchapplication
-
-data class MyApplicationRequest(
-    val teamId: Long
-)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/MatchServiceImpl.kt
@@ -10,6 +10,7 @@ import com.teamsparta.tikitaka.domain.match.model.Match
 import com.teamsparta.tikitaka.domain.match.model.SortCriteria
 import com.teamsparta.tikitaka.domain.match.repository.MatchRepository
 import com.teamsparta.tikitaka.domain.team.repository.TeamRepository
+import com.teamsparta.tikitaka.domain.team.repository.teamMember.TeamMemberRepository
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional
 class MatchServiceImpl(
     private val matchRepository: MatchRepository,
     private val teamRepository: TeamRepository,
+    private val teamMemberRepository: TeamMemberRepository,
 ) : MatchService {
 
     @Transactional
@@ -31,6 +33,9 @@ class MatchServiceImpl(
         request: PostMatchRequest,
     ): MatchResponse {
 
+        val teamMember = teamMemberRepository.findByUserId(principal.id)
+        val teamId = teamMember.team.id
+
         val match = matchRepository.save(
             Match.of(
                 title = request.title,
@@ -38,14 +43,14 @@ class MatchServiceImpl(
                 location = request.location,
                 content = request.content,
                 matchStatus = false,
-                teamId = request.teamId,
+                teamId = teamId!!,
                 userId = principal.id,
                 region = request.region,
             )
         )
 
-        val team = teamRepository.findByIdOrNull(request.teamId)
-            ?: throw ModelNotFoundException("team", request.teamId)
+        val team = teamRepository.findByIdOrNull(teamId)
+            ?: throw ModelNotFoundException("team", teamId)
 
         return MatchResponse.from(match)
     }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/matchapplication/MatchApplicationService.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v1/matchapplication/MatchApplicationService.kt
@@ -1,10 +1,12 @@
 package com.teamsparta.tikitaka.domain.match.service.v1.matchapplication
 
-import com.teamsparta.tikitaka.domain.match.dto.matchapplication.*
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MyApplicationsResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.ReplyApplicationRequest
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 
 interface MatchApplicationService {
-    fun applyMatch(userId: Long, request: CreateApplicationRequest, matchId: Long): MatchApplicationResponse
+    fun applyMatch(userId: Long, matchId: Long): MatchApplicationResponse
 
     fun replyMatchApplication(
         userId: Long,
@@ -13,7 +15,7 @@ interface MatchApplicationService {
     ): MatchApplicationResponse
 
 
-    fun getMyApplications(request: MyApplicationRequest): List<MyApplicationsResponse>
+    fun getMyApplications(userId: Long): List<MyApplicationsResponse>
 
     fun deleteMatchApplication(
         principal: UserPrincipal, applicationId: Long

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/MatchServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/MatchServiceImpl2.kt
@@ -10,6 +10,7 @@ import com.teamsparta.tikitaka.domain.match.model.Match
 import com.teamsparta.tikitaka.domain.match.model.SortCriteria
 import com.teamsparta.tikitaka.domain.match.repository.MatchRepository
 import com.teamsparta.tikitaka.domain.team.repository.TeamRepository
+import com.teamsparta.tikitaka.domain.team.repository.teamMember.TeamMemberRepository
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional
 class MatchServiceImpl2(
     private val matchRepository: MatchRepository,
     private val teamRepository: TeamRepository,
+    private val teamMemberRepository: TeamMemberRepository,
 ) : MatchService2 {
 
     @Transactional
@@ -31,6 +33,9 @@ class MatchServiceImpl2(
         request: PostMatchRequest,
     ): MatchResponse {
 
+        val teamMember = teamMemberRepository.findByUserId(principal.id)
+        val teamId = teamMember.team.id
+
         val match = matchRepository.save(
             Match.of(
                 title = request.title,
@@ -38,14 +43,14 @@ class MatchServiceImpl2(
                 location = request.location,
                 content = request.content,
                 matchStatus = false,
-                teamId = request.teamId,
+                teamId = teamId!!,
                 userId = principal.id,
                 region = request.region,
             )
         )
 
-        val team = teamRepository.findByIdOrNull(request.teamId)
-            ?: throw ModelNotFoundException("team", request.teamId)
+        val team = teamRepository.findByIdOrNull(teamId)
+            ?: throw ModelNotFoundException("team", teamId)
 
         return MatchResponse.from(match)
     }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
@@ -1,10 +1,12 @@
 package com.teamsparta.tikitaka.domain.match.service.v2.matchapplication2
 
-import com.teamsparta.tikitaka.domain.match.dto.matchapplication.*
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MyApplicationsResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.ReplyApplicationRequest
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 
 interface MatchApplicationService2 {
-    fun applyMatch(userId: Long, request: CreateApplicationRequest, matchId: Long): MatchApplicationResponse
+    fun applyMatch(userId: Long, matchId: Long): MatchApplicationResponse
 
     fun replyMatchApplication(
         userId: Long,
@@ -14,7 +16,7 @@ interface MatchApplicationService2 {
     ): MatchApplicationResponse
 
 
-    fun getMyApplications(request: MyApplicationRequest): List<MyApplicationsResponse>
+    fun getMyApplications(userId: Long): List<MyApplicationsResponse>
 
     fun cancelMatchApplication(
         principal: UserPrincipal, matchId: Long, applicationId: Long

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/request/ReassignRoleRequest.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/request/ReassignRoleRequest.kt
@@ -3,5 +3,5 @@ package com.teamsparta.tikitaka.domain.team.dto.request
 import com.teamsparta.tikitaka.domain.team.model.teammember.TeamRole
 
 data class ReassignRoleRequest(
-    val role: String,
+    val role: TeamRole,
 )

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/dto/LoginResponse.kt
@@ -1,6 +1,7 @@
 package com.teamsparta.tikitaka.domain.users.dto
 
 data class LoginResponse(
+    val userId: Long,
     val accessToken: String,
     val refreshToken: String
 )

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v1/UsersServiceImpl.kt
@@ -71,7 +71,7 @@ class UsersServiceImpl(
             role = role
         )
         redisUtils.saveRefreshToken(refreshToken)
-        return LoginResponse(accessToken = accessToken, refreshToken = refreshToken)
+        return LoginResponse(userId = user.id!!, accessToken = accessToken, refreshToken = refreshToken)
     }
 
     override fun logOut(token: String) {

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/jwt/JwtPlugin.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/jwt/JwtPlugin.kt
@@ -60,6 +60,7 @@ class JwtPlugin(
     fun validateRefreshTokenAndCreateToken(refreshToken: String): LoginResponse {
         val claims =
             validateToken(refreshToken).getOrElse { throw InvalidCredentialException("Invalid Refresh Token") }.payload
+        val userId = claims.subject.toLong()
         val subject = claims.subject
         val email = claims["email"].toString()
         val role: TeamRole? = claims["role"]?.let { TeamRole.valueOf(it as String) }
@@ -67,6 +68,6 @@ class JwtPlugin(
         val newAccessToken = generateAccessToken(subject, email, role.toString())
         val newRefreshToken = generateRefreshToken(subject, email, role.toString())
 
-        return LoginResponse(newAccessToken, newRefreshToken)
+        return LoginResponse(userId, newAccessToken, newRefreshToken)
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #87 

## 📝작업 내용

> Front에서 사용자의 TeamId를 찾을 수 없어, Service에서 TeamId를 찾아 전달하는 방식으로 변경
> Login 시, JWT와 함께 UserId 전달

## ✏️ 테스트 여부
- [x] 테스트완료
