### PR TITLE
✨ #94 - 매치 신청 내역 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
@@ -7,6 +7,9 @@ import com.teamsparta.tikitaka.domain.match.service.v2.matchapplication2.MatchAp
 import com.teamsparta.tikitaka.domain.team.model.teammember.TeamRole
 import com.teamsparta.tikitaka.infra.security.CustomPreAuthorize
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -55,5 +58,22 @@ class MatchApplicationController2(
         @AuthenticationPrincipal principal: UserPrincipal,
     ): ResponseEntity<List<MyApplicationsResponse>> {
         return ResponseEntity.ok(matchApplicationService.getMyApplications(principal.id))
+    }
+
+    @GetMapping("/{match-id}/match-applications")
+    fun getMatchApplications(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable(name = "match-id") matchId: Long,
+        @PageableDefault(size = 10) pageable: Pageable,
+        @RequestParam approveStatus: String?
+    ): ResponseEntity<Page<MatchApplicationResponse>> {
+        return ResponseEntity.status(HttpStatus.OK).body(
+            matchApplicationService.getMatchApplications(
+                principal.id,
+                matchId,
+                pageable,
+                approveStatus
+            )
+        )
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
@@ -1,6 +1,7 @@
 package com.teamsparta.tikitaka.domain.match.controller.v2.matchapplication2
 
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationsByIdResponse
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MyApplicationsResponse
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.ReplyApplicationRequest
 import com.teamsparta.tikitaka.domain.match.service.v2.matchapplication2.MatchApplicationService2
@@ -66,7 +67,7 @@ class MatchApplicationController2(
         @PathVariable(name = "match-id") matchId: Long,
         @PageableDefault(size = 10) pageable: Pageable,
         @RequestParam approveStatus: String?
-    ): ResponseEntity<Page<MatchApplicationResponse>> {
+    ): ResponseEntity<Page<MatchApplicationsByIdResponse>> {
         return ResponseEntity.status(HttpStatus.OK).body(
             matchApplicationService.getMatchApplications(
                 principal,

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/controller/v2/matchapplication2/MatchApplicationController2.kt
@@ -69,7 +69,7 @@ class MatchApplicationController2(
     ): ResponseEntity<Page<MatchApplicationResponse>> {
         return ResponseEntity.status(HttpStatus.OK).body(
             matchApplicationService.getMatchApplications(
-                principal.id,
+                principal,
                 matchId,
                 pageable,
                 approveStatus

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/matchapplication/MatchApplicationsByIdResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/matchapplication/MatchApplicationsByIdResponse.kt
@@ -1,23 +1,20 @@
 package com.teamsparta.tikitaka.domain.match.dto.matchapplication
 
-import com.teamsparta.tikitaka.domain.match.model.Match
 import com.teamsparta.tikitaka.domain.match.model.matchapplication.MatchApplication
 import java.time.LocalDateTime
 
-data class MatchApplicationResponse(
+data class MatchApplicationsByIdResponse(
     val id: Long,
     val applyUserId: Long,
-    val matchPost: Match,
     val applyTeamId: Long,
     val approveStatus: String,
     val createdAt: LocalDateTime
 ) {
     companion object {
-        fun from(matchApplication: MatchApplication): MatchApplicationResponse {
-            return MatchApplicationResponse(
+        fun from(matchApplication: MatchApplication): MatchApplicationsByIdResponse {
+            return MatchApplicationsByIdResponse(
                 id = matchApplication.id!!,
                 applyUserId = matchApplication.applyUserId,
-                matchPost = matchApplication.matchPost,
                 applyTeamId = matchApplication.applyTeamId,
                 approveStatus = matchApplication.approveStatus.name,
                 createdAt = matchApplication.createdAt

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/matchapplication/CustomMatchApplicationRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/repository/matchapplication/CustomMatchApplicationRepository.kt
@@ -1,9 +1,17 @@
 package com.teamsparta.tikitaka.domain.match.repository.matchapplication
 
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationsByIdResponse
 import com.teamsparta.tikitaka.domain.match.model.matchapplication.MatchApplication
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import java.time.LocalDate
 
 interface CustomMatchApplicationRepository {
     fun findByTeamIdAndMatchDate(teamId: Long, matchDate: LocalDate): List<MatchApplication>
     fun findByApplyTeamId(applyTeamId: Long): List<MatchApplication>
+    fun findApplicationsByMatchId(
+        pageable: Pageable,
+        matchId: Long,
+        approveStatus: String?
+    ): Page<MatchApplicationsByIdResponse>
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/MatchServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/MatchServiceImpl2.kt
@@ -82,7 +82,6 @@ class MatchServiceImpl2(
     ): MatchResponse {
 
         val match = findMatchById(matchId)
-
         if (match.userId != principal.id && !principal.authorities.contains(SimpleGrantedAuthority("ROLE_LEADER"))) throw AccessDeniedException(
             "You do not have permission to delete."
         )

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
@@ -1,6 +1,7 @@
 package com.teamsparta.tikitaka.domain.match.service.v2.matchapplication2
 
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationsByIdResponse
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MyApplicationsResponse
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.ReplyApplicationRequest
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
@@ -24,6 +25,6 @@ interface MatchApplicationService2 {
 
     fun getMatchApplications(
         principal: UserPrincipal, matchId: Long, pageable: Pageable, approveStatus: String?
-    ): Page<MatchApplicationResponse>
+    ): Page<MatchApplicationsByIdResponse>
 
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
@@ -23,10 +23,7 @@ interface MatchApplicationService2 {
     )
 
     fun getMatchApplications(
-        userId: Long,
-        matchId: Long,
-        pageable: Pageable,
-        approveStatus: String?
+        principal: UserPrincipal, matchId: Long, pageable: Pageable, approveStatus: String?
     ): Page<MatchApplicationResponse>
 
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationService2.kt
@@ -4,6 +4,8 @@ import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicatio
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MyApplicationsResponse
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.ReplyApplicationRequest
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface MatchApplicationService2 {
     fun applyMatch(userId: Long, matchId: Long): MatchApplicationResponse
@@ -15,10 +17,16 @@ interface MatchApplicationService2 {
         request: ReplyApplicationRequest
     ): MatchApplicationResponse
 
-
     fun getMyApplications(userId: Long): List<MyApplicationsResponse>
-
     fun cancelMatchApplication(
         principal: UserPrincipal, matchId: Long, applicationId: Long
     )
+
+    fun getMatchApplications(
+        userId: Long,
+        matchId: Long,
+        pageable: Pageable,
+        approveStatus: String?
+    ): Page<MatchApplicationResponse>
+
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
@@ -4,6 +4,7 @@ import com.teamsparta.tikitaka.domain.common.exception.AccessDeniedException
 import com.teamsparta.tikitaka.domain.common.exception.ModelNotFoundException
 import com.teamsparta.tikitaka.domain.common.exception.TeamAlreadyAppliedException
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationResponse
+import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MatchApplicationsByIdResponse
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.MyApplicationsResponse
 import com.teamsparta.tikitaka.domain.match.dto.matchapplication.ReplyApplicationRequest
 import com.teamsparta.tikitaka.domain.match.model.Match
@@ -103,7 +104,7 @@ class MatchApplicationServiceImpl2(
 
     override fun getMatchApplications(
         principal: UserPrincipal, matchId: Long, pageable: Pageable, approveStatus: String?
-    ): Page<MatchApplicationResponse> {
+    ): Page<MatchApplicationsByIdResponse> {
         val matchPost = matchRepository.findByIdOrNull(matchId) ?: throw ModelNotFoundException(
             "recruitment",
             matchId

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
@@ -16,6 +16,8 @@ import com.teamsparta.tikitaka.domain.team.repository.teamMember.TeamMemberRepos
 import com.teamsparta.tikitaka.domain.users.repository.UsersRepository
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 import jakarta.transaction.Transactional
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.stereotype.Service
@@ -54,10 +56,7 @@ class MatchApplicationServiceImpl2(
 
     @Transactional
     override fun replyMatchApplication(
-        userId: Long,
-        matchId: Long,
-        applicationId: Long,
-        request: ReplyApplicationRequest
+        userId: Long, matchId: Long, applicationId: Long, request: ReplyApplicationRequest
     ): MatchApplicationResponse {
         usersRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User", userId)
         val (approveStatus) = request
@@ -102,6 +101,12 @@ class MatchApplicationServiceImpl2(
             .map { application -> MyApplicationsResponse.from(application) }
     }
 
+    override fun getMatchApplications(
+        userId: Long, matchId: Long, pageable: Pageable, approveStatus: String?
+    ): Page<MatchApplicationResponse> {
+        TODO()
+    }
+
     private fun findUserById(userId: Long) =
         usersRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User", userId)
 
@@ -110,8 +115,7 @@ class MatchApplicationServiceImpl2(
 
     private fun findApplicationById(applicationId: Long) =
         matchApplicationRepository.findByIdOrNull(applicationId) ?: throw ModelNotFoundException(
-            "MatchApplication",
-            applicationId
+            "MatchApplication", applicationId
         )
 
     private fun validateMatchAvailability(matchPost: Match, teamId: Long) {

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/service/v2/matchapplication2/MatchApplicationServiceImpl2.kt
@@ -102,9 +102,18 @@ class MatchApplicationServiceImpl2(
     }
 
     override fun getMatchApplications(
-        userId: Long, matchId: Long, pageable: Pageable, approveStatus: String?
+        principal: UserPrincipal, matchId: Long, pageable: Pageable, approveStatus: String?
     ): Page<MatchApplicationResponse> {
-        TODO()
+        val matchPost = matchRepository.findByIdOrNull(matchId) ?: throw ModelNotFoundException(
+            "recruitment",
+            matchId
+        )
+        if (matchPost.userId != principal.id && !principal.authorities.contains(SimpleGrantedAuthority("ROLE_LEADER"))) throw AccessDeniedException(
+            "You do not have permission to get match applications."
+        )
+        val applications =
+            matchApplicationRepository.findApplicationsByMatchId(pageable, matchId, approveStatus)
+        return applications
     }
 
     private fun findUserById(userId: Long) =


### PR DESCRIPTION
## #️⃣연관된 이슈

> #94 

## 📝작업 내용

> QueryDSL 활용 자신의 팀이 올린 매치에 대한 신청 내역들을 조회할 수 있는 API입니다.

## ✏️ 테스트 여부
- [x] 테스트완료
