### PR TITLE
:bug: #100 - MatchApplicationsByIdResponse 내부 데이터 변경

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/matchapplication/MatchApplicationsByIdResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/matchapplication/MatchApplicationsByIdResponse.kt
@@ -5,20 +5,27 @@ import java.time.LocalDateTime
 
 data class MatchApplicationsByIdResponse(
     val id: Long,
-    val applyUserId: Long,
-    val applyTeamId: Long,
+    val applyUserName: String,
+    val applyTeamName: String,
     val approveStatus: String,
     val createdAt: LocalDateTime
 ) {
     companion object {
-        fun from(matchApplication: MatchApplication): MatchApplicationsByIdResponse {
+        fun from(
+            matchApplication: MatchApplication,
+            userName: String,
+            teamName: String
+        ): MatchApplicationsByIdResponse {
             return MatchApplicationsByIdResponse(
                 id = matchApplication.id!!,
-                applyUserId = matchApplication.applyUserId,
-                applyTeamId = matchApplication.applyTeamId,
+                applyUserName = userName,
+                applyTeamName = teamName,
                 approveStatus = matchApplication.approveStatus.name,
                 createdAt = matchApplication.createdAt
             )
         }
     }
 }
+
+
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> #100 

## 📝작업 내용

> MatchApplicationsByIdResponse 안 데이터 변경 ( UserId, TeamId -> UserName, TeamName )

## 💬리뷰 요구사항

> 이전 Test 목적으로 데이터를 임의로 집어넣고, 삭제하다 보니 NullPoint 오류가 발생하여 임시로 NullPoint를 처리하는 로직이 함께 들어가 있는 부분 참고 부탁드리겠습니다.

## ✏️ 테스트 여부
- [x] 테스트완료
