### PR TITLE
✨ #156 - Spring Batch 활용 TeamRanking Update 기능 추가

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/repository/EvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/repository/EvaluationRepositoryImpl.kt
@@ -16,7 +16,7 @@ class EvaluationRepositoryImpl : CustomEvaluationRepository, QueryDslSupport() {
             .selectFrom(evaluation)
             .where(
                 evaluation.createdAt.between(startDate, endDate)
-                    .and(evaluation.evaluationStatus.isTrue) // EvaluateStatus가 true인 조건 추가
+                    .and(evaluation.evaluationStatus.isTrue)
             )
             .fetch()
     }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/controller/v3/TeamController3.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/controller/v3/TeamController3.kt
@@ -1,13 +1,16 @@
 package com.teamsparta.tikitaka.domain.team.controller.v3
 
 
+import com.teamsparta.tikitaka.domain.common.Region
 import com.teamsparta.tikitaka.domain.team.dto.request.TeamRequest
 import com.teamsparta.tikitaka.domain.team.dto.response.PageResponse
+import com.teamsparta.tikitaka.domain.team.dto.response.TeamRankResponse
 import com.teamsparta.tikitaka.domain.team.dto.response.TeamResponse
 import com.teamsparta.tikitaka.domain.team.model.teammember.TeamRole
 import com.teamsparta.tikitaka.domain.team.service.v3.TeamService3
 import com.teamsparta.tikitaka.infra.security.CustomPreAuthorize
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
+import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -83,5 +86,12 @@ class TeamController3(
         return ResponseEntity.status(HttpStatus.OK).body(teamService.getTeam(teamId))
     }
 
-
+    @GetMapping("/ranks")
+    fun getTeamRanks(
+        @RequestParam("region", required = false) region: Region?,
+        @RequestParam("page", defaultValue = "0") page: Int,
+        @RequestParam("size", defaultValue = "10") size: Int,
+    ): ResponseEntity<Page<TeamRankResponse>> {
+        return ResponseEntity.status(HttpStatus.OK).body(teamService.getTeamRanks(region, page, size))
+    }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamRankResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamRankResponse.kt
@@ -1,0 +1,24 @@
+package com.teamsparta.tikitaka.domain.team.dto.response
+
+import com.teamsparta.tikitaka.domain.team.model.Team
+
+data class TeamRankResponse(
+    val id: Long,
+    val name: String,
+    val tierScore: Int,
+    val rank: Long?,
+    val region: String
+) {
+    fun from(
+        team: Team
+    ): TeamRankResponse {
+        return TeamRankResponse(
+            team.id!!,
+            team.name,
+            team.tierScore,
+            team.rank,
+            team.region.name,
+        )
+    }
+}
+

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamResponse.kt
@@ -12,6 +12,7 @@ data class TeamResponse(
     val tierScore: Int,
     val mannerScore: Int,
     val attendanceScore: Int,
+    val rank: Long?,
     val recruitStatus: Boolean,
     val region: String,
     val createAt: LocalDateTime
@@ -31,6 +32,7 @@ data class TeamResponse(
                 team.tierScore,
                 team.mannerScore,
                 team.attendanceScore,
+                team.rank,
                 team.recruitStatus,
                 team.region.name,
                 team.createdAt

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/Team.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/Team.kt
@@ -30,6 +30,9 @@ class Team(
     @Column(name = "attendance")
     var attendanceScore: Int = 0,
 
+    @Column(name = "rank")
+    var rank: Long? = null,
+
     @Column(name = "recruit_status", nullable = false)
     var recruitStatus: Boolean = false,
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/TeamRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/TeamRepository.kt
@@ -1,8 +1,14 @@
 package com.teamsparta.tikitaka.domain.team.repository
 
+import com.teamsparta.tikitaka.domain.common.Region
 import com.teamsparta.tikitaka.domain.team.model.Team
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface TeamRepository : JpaRepository<Team, Long>, CustomTeamRepository
+interface TeamRepository : JpaRepository<Team, Long>, CustomTeamRepository {
+    fun findByRegionAndRankIsNotNull(region: Region, pageable: Pageable): Page<Team>
+    fun findAllByRankIsNotNull(pageable: Pageable): Page<Team>
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v3/TeamService3.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v3/TeamService3.kt
@@ -1,9 +1,12 @@
 package com.teamsparta.tikitaka.domain.team.service.v3
 
+import com.teamsparta.tikitaka.domain.common.Region
 import com.teamsparta.tikitaka.domain.team.dto.request.TeamRequest
 import com.teamsparta.tikitaka.domain.team.dto.response.PageResponse
+import com.teamsparta.tikitaka.domain.team.dto.response.TeamRankResponse
 import com.teamsparta.tikitaka.domain.team.dto.response.TeamResponse
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
+import org.springframework.data.domain.Page
 
 interface TeamService3 {
 
@@ -19,11 +22,8 @@ interface TeamService3 {
     fun getTeam(teamId: Long): TeamResponse
 
     fun searchTeamListByName(
-        region: String?,
-        page: Int,
-        size: Int,
-        sortBy: String,
-        direction: String,
-        name: String
+        region: String?, page: Int, size: Int, sortBy: String, direction: String, name: String
     ): PageResponse<TeamResponse>
+
+    fun getTeamRanks(region: Region?, page: Int, size: Int): Page<TeamRankResponse>
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/security/config/SecurityConfig.kt
@@ -46,6 +46,7 @@ class SecurityConfig(
                     "/oauth/**",
                     "/login/oauth2/**",
                     "/my-monitor/**",
+                    "/api/v3/teams/ranks",
 
                     ).permitAll()
                     .anyRequest().authenticated()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #156 

## 📝작업 내용

> - Spring Batch 활용 TeamRanking Update 기능 추가
> - TeamService.getTeamRanks API 기능 생성

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> - 랭킹 조회의 경우, 최대 100위까지 조회 가능합니다. 지역 별로 필터링하여 랭킹이 높은 순서대로 확인해볼 수 있으나,
현재까지 지역 별 랭킹을 제공하지는 않습니다 (추후 업데이트 예정)

## ✏️ 테스트 여부
- [x] 테스트완료
