### PR TITLE
♻️ #163 - Spring Batch 내부 "ItemReader" "QuerydslPagingItemReader"로 변경 진행

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ allOpen {
     annotation("jakarta.persistence.MappedSuperclass")
     annotation("jakarta.persistence.Embeddable")
 }
+
 noArg {
     annotation("jakarta.persistence.Entity")
     annotation("jakarta.persistence.MappedSuperclass")
@@ -46,38 +47,34 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-aop")
-    implementation("org.springframework.boot:spring-boot-starter")
-    implementation("io.jsonwebtoken:jjwt-api:0.12.3")
-    implementation("com.h2database:h2")
-    implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("com.amazonaws:aws-java-sdk-s3:1.12.741")
-    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
-    implementation("com.querydsl:querydsl-jpa:$queryDslVersion:jakarta")
     implementation("org.springframework.boot:spring-boot-starter-batch:3.0.6")
     implementation("org.springframework:spring-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("io.micrometer:micrometer-registry-prometheus")
+    implementation("com.amazonaws:aws-java-sdk-s3:1.12.741")
+    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
+    implementation("com.h2database:h2")
+    implementation("com.querydsl:querydsl-jpa:$queryDslVersion:jakarta")
+    implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
 
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0")
     kapt("com.querydsl:querydsl-apt:$queryDslVersion:jakarta")
     kapt("jakarta.annotation:jakarta.annotation-api")
     kapt("jakarta.persistence:jakarta.persistence-api")
-    implementation("org.springframework.boot:spring-boot-starter-batch")
-    implementation("org.springframework.boot:spring-boot-starter-aop")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
@@ -89,13 +86,9 @@ dependencies {
     testImplementation("io.mockk:mockk:$mockkVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-
-
     runtimeOnly("org.postgresql:postgresql")
-    runtimeOnly("com.h2database:h2")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
-
 }
 
 kotlin {

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/repository/CustomEvaluationRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/repository/CustomEvaluationRepository.kt
@@ -1,10 +1,11 @@
 package com.teamsparta.tikitaka.domain.evaluation.repository
 
+import com.querydsl.jpa.impl.JPAQuery
 import com.teamsparta.tikitaka.domain.evaluation.model.Evaluation
 import java.time.LocalDateTime
 
 interface CustomEvaluationRepository {
     fun findEvaluationsBetween(startDate: LocalDateTime, endDate: LocalDateTime): List<Evaluation>
-
     fun softDeleteOldEvaluations(threshold: LocalDateTime, now: LocalDateTime)
+    fun findEvaluationsWithPagination(): JPAQuery<Evaluation>
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/repository/EvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/repository/EvaluationRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.teamsparta.tikitaka.domain.evaluation.repository
 
+import com.querydsl.jpa.impl.JPAQuery
 import com.teamsparta.tikitaka.domain.evaluation.model.Evaluation
 import com.teamsparta.tikitaka.domain.evaluation.model.QEvaluation
 import com.teamsparta.tikitaka.infra.querydsl.QueryDslSupport
@@ -12,23 +13,21 @@ class EvaluationRepositoryImpl : CustomEvaluationRepository, QueryDslSupport() {
     override fun findEvaluationsBetween(startDate: LocalDateTime, endDate: LocalDateTime): List<Evaluation> {
         val evaluation = QEvaluation.evaluation
 
-        return queryFactory
-            .selectFrom(evaluation)
-            .where(
-                evaluation.createdAt.between(startDate, endDate)
-                    .and(evaluation.evaluationStatus.isTrue)
-            )
-            .fetch()
+        return queryFactory.selectFrom(evaluation).where(
+            evaluation.evaluationStatus.isTrue
+        ).fetch()
     }
 
     override fun softDeleteOldEvaluations(threshold: LocalDateTime, now: LocalDateTime) {
         val evaluation = QEvaluation.evaluation
-        queryFactory.update(evaluation)
-            .set(evaluation.deletedAt, now)
-            .where(
-                evaluation.createdAt.lt(threshold)
-                    .and(evaluation.deletedAt.isNull)
-            )
-            .execute()
+        queryFactory.update(evaluation).set(evaluation.deletedAt, now).where(
+            evaluation.createdAt.lt(threshold).and(evaluation.deletedAt.isNull)
+        ).execute()
+    }
+
+    override fun findEvaluationsWithPagination(): JPAQuery<Evaluation> {
+        return queryFactory.selectFrom(QEvaluation.evaluation)
+            .where(QEvaluation.evaluation.evaluationStatus.isTrue)
+            .orderBy(QEvaluation.evaluation.id.asc())
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/service/v3/EvaluationScheduler.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/service/v3/EvaluationScheduler.kt
@@ -11,7 +11,7 @@ class EvaluationScheduler(
     private val evaluationService: EvaluationService,
 ) {
 
-    @Scheduled(fixedRate = 30000)
+    @Scheduled(fixedRate = 600000)
     fun createEvaluations() {
         val now = LocalDateTime.now()
         val twoHoursAgo = now.minusHours(2)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamRankResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamRankResponse.kt
@@ -7,6 +7,7 @@ data class TeamRankResponse(
     val name: String,
     val tierScore: Int,
     val rank: Long?,
+    val regionRank: Long?,
     val region: String
 ) {
     fun from(
@@ -17,6 +18,7 @@ data class TeamRankResponse(
             team.name,
             team.tierScore,
             team.rank,
+            team.regionRank,
             team.region.name,
         )
     }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/Team.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/model/Team.kt
@@ -33,6 +33,9 @@ class Team(
     @Column(name = "rank")
     var rank: Long? = null,
 
+    @Column(name = "region_rank")
+    var regionRank: Long? = null,
+
     @Column(name = "recruit_status", nullable = false)
     var recruitStatus: Boolean = false,
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v3/TeamServiceImpl3.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v3/TeamServiceImpl3.kt
@@ -119,7 +119,13 @@ class TeamServiceImpl3(
         val fixedPage = page.coerceAtMost(9)
         val fixedSize = size.coerceAtMost(10)
 
-        val pageable = PageRequest.of(fixedPage, fixedSize, Sort.by(Sort.Direction.ASC, "rank"))
+        val sort = if (region != null) {
+            Sort.by(Sort.Direction.ASC, "regionRank")
+        } else {
+            Sort.by(Sort.Direction.ASC, "rank")
+        }
+
+        val pageable = PageRequest.of(fixedPage, fixedSize, sort)
 
         val teams = if (region != null) {
             teamRepository.findByRegionAndRankIsNotNull(region, pageable)
@@ -133,6 +139,7 @@ class TeamServiceImpl3(
                 name = team.name,
                 tierScore = team.tierScore,
                 rank = team.rank,
+                regionRank = team.regionRank,
                 region = team.region.name
             )
         }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v3/TeamServiceImpl3.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v3/TeamServiceImpl3.kt
@@ -114,6 +114,7 @@ class TeamServiceImpl3(
         return TeamResponse.from(team)
     }
 
+    @Cacheable("teamRankRedis", cacheManager = "redisCacheManager")
     override fun getTeamRanks(region: Region?, page: Int, size: Int): Page<TeamRankResponse> {
         val fixedPage = page.coerceAtMost(9)
         val fixedSize = size.coerceAtMost(10)

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/batch/BatchConfig.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/batch/BatchConfig.kt
@@ -14,6 +14,7 @@ import org.springframework.batch.item.ItemProcessor
 import org.springframework.batch.item.ItemReader
 import org.springframework.batch.item.ItemWriter
 import org.springframework.batch.item.support.ListItemReader
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.transaction.PlatformTransactionManager
@@ -77,6 +78,7 @@ class BatchConfig(
         }
     }
 
+    @CacheEvict("teamRankRedis", cacheManager = "redisCacheManager", allEntries = true)
     @StepScope
     @Bean
     fun teamItemWriter(): ItemWriter<Team> {
@@ -90,7 +92,6 @@ class BatchConfig(
             var currentRank = 1L
             var previousScore: Int? = null
             var sameRankCount = 0
-
             teamRanking.forEach { team ->
                 if (team.tierScore == 0) {
                     team.rank = null

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/batch/BatchConfig.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/batch/BatchConfig.kt
@@ -107,8 +107,38 @@ class BatchConfig(
                     previousScore = team.tierScore
                 }
             }
+
             teamRanking.forEach { team ->
                 teamRepository.save(team)
+            }
+
+            val teamsByRegion = teams.groupBy { it.region }
+
+            teamsByRegion.forEach { (region, regionTeams) ->
+                val regionRanking = regionTeams.sortedByDescending { it.tierScore }
+
+                var regionCurrentRank = 1L
+                var regionPreviousScore: Int? = null
+                var regionSameRankCount = 0
+
+                regionRanking.forEach { team ->
+                    if (team.tierScore == 0) {
+                        team.regionRank = null
+                    } else {
+                        if (regionPreviousScore != null && team.tierScore == regionPreviousScore) {
+                            regionSameRankCount += 1
+                        } else {
+                            regionCurrentRank += regionSameRankCount
+                            regionSameRankCount = 1
+                        }
+
+                        team.regionRank = regionCurrentRank
+                        regionPreviousScore = team.tierScore
+                    }
+                }
+                regionRanking.forEach { team ->
+                    teamRepository.save(team)
+                }
             }
         }
     }

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/batch/QuerydslPagingItemReader.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/batch/QuerydslPagingItemReader.kt
@@ -1,0 +1,71 @@
+package com.teamsparta.tikitaka.infra.batch
+
+import com.querydsl.jpa.impl.JPAQuery
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.EntityManagerFactory
+import org.springframework.batch.item.database.AbstractPagingItemReader
+import org.springframework.util.CollectionUtils
+import java.util.concurrent.CopyOnWriteArrayList
+
+open class QuerydslPagingItemReader<T>(
+    private val entityManagerFactory: EntityManagerFactory, val queryCreator: (JPAQueryFactory) -> JPAQuery<T>
+) : AbstractPagingItemReader<T>() {
+
+    private lateinit var entityManager: EntityManager
+
+    private val jpaPropertyMap = mutableMapOf<String, Any>()
+    var transacted = true
+    var pageOffset = true
+
+    override fun doOpen() {
+        super.doOpen()
+        entityManager = entityManagerFactory.createEntityManager(jpaPropertyMap)
+    }
+
+    override fun doReadPage() {
+        clearIfTransacted()
+
+        val query = createQuery().limit(pageSize.toLong())
+
+        initResults()
+        fetchQuery(query)
+    }
+
+    private fun clearIfTransacted() {
+        if (transacted) {
+            entityManager.clear()
+        }
+    }
+
+    private fun createQuery(): JPAQuery<T> = queryCreator(JPAQueryFactory(entityManager))
+
+    private fun initResults() {
+        if (CollectionUtils.isEmpty(results)) {
+            results = CopyOnWriteArrayList()
+        } else {
+            results.clear()
+        }
+    }
+
+    private fun fetchQuery(query: JPAQuery<T>) {
+        if (!transacted) {
+            val queryResult = query.fetch()
+            for (entity in queryResult) {
+                entityManager.detach(entity)
+                results.add(entity)
+            }
+        } else {
+            results.addAll(query.fetch())
+        }
+    }
+
+    override fun doClose() {
+        entityManager.close()
+        super.doClose()
+    }
+
+    override fun getPageSize(): Int {
+        return if (pageOffset) super.getPageSize() else 0
+    }
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/infra/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/infra/redis/RedisConfig.kt
@@ -40,9 +40,16 @@ class RedisConfig {
     @Bean()
     fun cacheManager(): CacheManager {
         val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofMinutes(1))
+            .entryTtl(Duration.ofMinutes(10))
+
+        val teamRankCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofDays(1))
+
+        val cacheConfigurations = mapOf("teamRankRedis" to teamRankCacheConfiguration)
+
         return RedisCacheManager.builder(lettuceConnectionFactory())
             .cacheDefaults(redisCacheConfiguration)
+            .withInitialCacheConfigurations(cacheConfigurations)
             .build()
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #163 

## 📝작업 내용

> - getTeamRanks 함수에 @Cacheable Annotation 적용 (ttl 하루로 설정 진행)
> - ItemWriter 내부에 @CacheEvict 적용
> - Team Table 내부 RegionRanking Column 추가, 지역 별 랭킹도 계산하는 로직 추가 구현 진행
> - 기존 ItemReader Type 'ListItemReader ' → 'QuerydslPagingItemReader'로 변경 진행

## ✏️ 테스트 여부
- (미완료 시) 이유 : Cache 적용 외 Spring Batch Part Test 미진행, Ngrinder 활용 Test 진행 예정
