### PR TITLE
🩹 #171 - createEvaluationsForMatch 변수명 수정

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/service/v3/EvaluationServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/service/v3/EvaluationServiceImpl.kt
@@ -57,22 +57,22 @@ class EvaluationServiceImpl(
 
         if (evaluationRepository.existsByEvaluatorIdAndEvaluateeTeamId(match.hostId, match.guestTeamId))
             throw IllegalArgumentException("이미 평가표가 생성 되었습니다")
-            
-        val hostTeamEvaluation = Evaluation(
+
+        val evaluationFromHostTeam = Evaluation(
             evaluatorTeamId = match.hostTeamId,
             evaluateeTeamId = match.guestTeamId,
             evaluatorId = match.hostId,
             createdAt = LocalDateTime.now()
         )
-        val guestTeamEvaluation = Evaluation(
+        val evaluationFromGuestTeam = Evaluation(
             evaluatorTeamId = match.guestTeamId,
             evaluateeTeamId = match.hostTeamId,
             evaluatorId = match.guestId,
             createdAt = LocalDateTime.now()
         )
 
-        evaluationRepository.save(hostTeamEvaluation)
-        evaluationRepository.save(guestTeamEvaluation)
+        evaluationRepository.save(evaluationFromHostTeam)
+        evaluationRepository.save(evaluationFromGuestTeam)
 
         match.evaluationCreatedTrue()
         successMatchRepository.save(match)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #171 

## 📝작업 내용

> EvaluationService.createEvaluationsForMatch 의 변수명 수정
hostTeamEvaluation -> evaluationFromHostTeam
guestTeamEvaluation -> evaluationFromGuestTeam

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✏️ 테스트 여부
- [ ] 테스트완료
- (미완료 시) 이유 : 
