### PR TITLE
:recycle: #183 - QuerydslPagingItemReader → QuerydslZeroOffsetItemReader 변경

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/repository/CustomEvaluationRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/repository/CustomEvaluationRepository.kt
@@ -1,10 +1,11 @@
 package com.teamsparta.tikitaka.domain.evaluation.repository
 
 import com.querydsl.jpa.impl.JPAQuery
+import com.querydsl.jpa.impl.JPAQueryFactory
 import com.teamsparta.tikitaka.domain.evaluation.model.Evaluation
 import java.time.LocalDateTime
 
 interface CustomEvaluationRepository {
     fun softDeleteOldEvaluations(threshold: LocalDateTime, now: LocalDateTime)
-    fun findEvaluationsWithPagination(): JPAQuery<Evaluation>
+    fun findEvaluationsWithPagination(queryFactory: JPAQueryFactory): JPAQuery<Evaluation>
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/repository/EvaluationRepositoryImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/evaluation/repository/EvaluationRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package com.teamsparta.tikitaka.domain.evaluation.repository
 
 import com.querydsl.jpa.impl.JPAQuery
+import com.querydsl.jpa.impl.JPAQueryFactory
 import com.teamsparta.tikitaka.domain.evaluation.model.Evaluation
 import com.teamsparta.tikitaka.domain.evaluation.model.QEvaluation
+import com.teamsparta.tikitaka.domain.evaluation.model.QEvaluation.evaluation
 import com.teamsparta.tikitaka.infra.querydsl.QueryDslSupport
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
@@ -16,9 +18,10 @@ class EvaluationRepositoryImpl : CustomEvaluationRepository, QueryDslSupport() {
         ).execute()
     }
 
-    override fun findEvaluationsWithPagination(): JPAQuery<Evaluation> {
-        return queryFactory.selectFrom(QEvaluation.evaluation)
-            .where(QEvaluation.evaluation.evaluationStatus.isTrue)
-            .orderBy(QEvaluation.evaluation.id.asc())
+    override fun findEvaluationsWithPagination(queryFactory: JPAQueryFactory): JPAQuery<Evaluation> {
+        return queryFactory.selectFrom(evaluation)
+            .where(evaluation.evaluationStatus.isTrue)
+            .orderBy(evaluation.id.asc())
     }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #183 

## 📝작업 내용

> QuerydslPagingItemReader → QuerydslZeroOffsetItemReader 변경
자주 조회되는 query 체크 Index 처리 진행

## 💬참고 사항

> 성능적으로 개선이 되었으나 (Step 소요시간 약 10초 단축) 차이가 미비하여 추가적인 문제점 파악 필요
다음 이슈에서는 각 Reader, Processor, Writer 별 소요되는 시간 체크, 개선이 필요한 부분 확인 후 개선 예정

## ✏️ 테스트 여부
- [X] 테스트완료
