### PR TITLE
:sparkles: #184 - 회원가입 시 이메일 인증이 된 이메일만 가입할 수 있는 기능 추가

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/common/util/RedisUtils.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/common/util/RedisUtils.kt
@@ -79,4 +79,9 @@ class RedisUtils(
         val verifiedEmailsKey = getVerifiedEmailsKey(email)
         return (redisTemplate.opsForSet().remove(verifiedEmailsKey, email) ?: 0) > 0
     }
+
+    fun setVerifiedEmailWithExpiration(email: String) {
+        val verifiedEmailsKey = getVerifiedEmailsKey(email)
+        redisTemplate.opsForValue().set(verifiedEmailsKey, email, Duration.ofSeconds(300))
+    }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/common/util/RedisUtils.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/common/util/RedisUtils.kt
@@ -14,6 +14,7 @@ class RedisUtils(
         private val DURATION_TIME = 1000 * 60 * 60 * 24L
         private val REFRESH_TOKEN_DURATION_TIME = 1000 * 60 * 60 * 24L * 7
         private const val KEY_PREFIX = "refreshToken"
+        private const val VERIFIED_EMAILS_KEY = "verified_emails"
     }
 
     fun getData(key: String): String? {
@@ -58,5 +59,24 @@ class RedisUtils(
         val valueOperations: ValueOperations<String, String> = redisTemplate.opsForValue()
         val expireDuration = Duration.ofSeconds(duration)
         valueOperations.set(key, value, expireDuration)
+    }
+
+    private fun getVerifiedEmailsKey(email: String): String {
+        return "$VERIFIED_EMAILS_KEY:$email"
+    }
+
+    fun setVerifiedEmail(email: String) {
+        val verifiedEmailsKey = getVerifiedEmailsKey(email)
+        redisTemplate.opsForSet().add(verifiedEmailsKey, email)
+    }
+
+    fun isVerifiedEmail(email: String): Boolean {
+        val verifiedEmailsKey = getVerifiedEmailsKey(email)
+        return redisTemplate.opsForSet().isMember(verifiedEmailsKey, email) ?: false
+    }
+
+    fun deleteEmailData(email: String): Boolean {
+        val verifiedEmailsKey = getVerifiedEmailsKey(email)
+        return (redisTemplate.opsForSet().remove(verifiedEmailsKey, email) ?: 0) > 0
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/common/util/RedisUtils.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/common/util/RedisUtils.kt
@@ -82,6 +82,7 @@ class RedisUtils(
 
     fun setVerifiedEmailWithExpiration(email: String) {
         val verifiedEmailsKey = getVerifiedEmailsKey(email)
-        redisTemplate.opsForValue().set(verifiedEmailsKey, email, Duration.ofSeconds(300))
+        redisTemplate.opsForSet().add(verifiedEmailsKey, email)
+        redisTemplate.expire(verifiedEmailsKey, Duration.ofSeconds(300))
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/controller/v3/UsersController3.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/controller/v3/UsersController3.kt
@@ -51,6 +51,7 @@ class UsersController3(
         @RequestBody dto: CodeDto
     ): ResponseEntity<String> {
         return if (emailService.verificationEmail(email, dto.code)) {
+            redisUtils.setVerifiedEmailWithExpiration(email)
             redisUtils.deleteData(email)
             ResponseEntity.ok("인증 성공. 회원가입을 진행하세요.")
         } else {

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/controller/v3/UsersController3.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/controller/v3/UsersController3.kt
@@ -1,5 +1,6 @@
 package com.teamsparta.tikitaka.domain.users.controller.v3
 
+import com.teamsparta.tikitaka.domain.common.util.RedisUtils
 import com.teamsparta.tikitaka.domain.recruitment.dto.recruitmentapplication.RecruitmentApplicationResponse
 import com.teamsparta.tikitaka.domain.recruitment.service.v2.recruitmentapplication.RecruitmentApplicationService
 import com.teamsparta.tikitaka.domain.users.dto.CodeDto
@@ -33,7 +34,8 @@ import org.springframework.web.bind.annotation.RestController
 class UsersController3(
     private val userService: UsersService3,
     private val recruitmentApplicationService: RecruitmentApplicationService,
-    private val emailService: EmailService
+    private val emailService: EmailService,
+    private val redisUtils: RedisUtils
 ) {
     @GetMapping("/create-code")
     fun createCode(
@@ -49,18 +51,18 @@ class UsersController3(
         @RequestBody dto: CodeDto
     ): ResponseEntity<String> {
         return if (emailService.verificationEmail(email, dto.code)) {
-            ResponseEntity.ok(emailService.makeMemberId(email))
+            redisUtils.deleteData(email)
+            ResponseEntity.ok("인증 성공. 회원가입을 진행하세요.")
         } else {
-            ResponseEntity.notFound().build()
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body("인증 코드가 유효하지 않습니다.")
         }
     }
 
     @PostMapping("/sign-up")
     fun signUp(
-        @RequestBody request: SignUpRequest,
-        @RequestParam code: String
+        @RequestBody request: SignUpRequest
     ): ResponseEntity<UserDto> {
-        return ResponseEntity.ok(userService.signUp(request, code))
+        return ResponseEntity.ok(userService.signUp(request))
     }
 
     @PostMapping("/log-in")

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v3/EmailService.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v3/EmailService.kt
@@ -6,5 +6,5 @@ interface EmailService {
     fun createEMail(email: String): MimeMessage
     fun sendEmail(email: String)
     fun verificationEmail(email: String, number: String): Boolean
-    fun makeMemberId(email: String): String
+    fun isVerified(email: String): Boolean
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v3/EmailServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v3/EmailServiceImpl.kt
@@ -5,8 +5,6 @@ import jakarta.mail.internet.MimeMessage
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Service
-import java.security.MessageDigest
-import java.time.LocalDateTime
 import kotlin.random.Random
 
 @Service
@@ -55,13 +53,14 @@ class EmailServiceImpl(
 
     override fun verificationEmail(email: String, number: String): Boolean {
         val codeFoundByEmail = redisUtils.getData(email)
-        return codeFoundByEmail?.equals(number) ?: false
+        if (codeFoundByEmail != null && codeFoundByEmail == number) {
+            redisUtils.setVerifiedEmail(email)
+            return true
+        }
+        return false
     }
 
-    override fun makeMemberId(email: String): String {
-        val md = MessageDigest.getInstance("SHA-256")
-        md.update(email.toByteArray())
-        md.update(LocalDateTime.now().toString().toByteArray())
-        return md.digest().joinToString("") { String.format("%02x", it) }
+    override fun isVerified(email: String): Boolean {
+        return redisUtils.isVerifiedEmail(email)
     }
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v3/UsersService3.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v3/UsersService3.kt
@@ -11,7 +11,7 @@ import com.teamsparta.tikitaka.domain.users.dto.UserDto
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 
 interface UsersService3 {
-    fun signUp(request: SignUpRequest, code: String): UserDto
+    fun signUp(request: SignUpRequest): UserDto
     fun logIn(request: LoginRequest): LoginResponse
     fun logOut(token: String)
     fun validateRefreshTokenAndCreateToken(refreshToken: String): LoginResponse

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v3/UsersServiceImpl3.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v3/UsersServiceImpl3.kt
@@ -43,7 +43,7 @@ class UsersServiceImpl3(
 
         val isVerified = redisUtils.isVerifiedEmail(request.email)
         if (!isVerified) {
-            throw InvalidCredentialException("이메일 인증이 필요합니다.")
+            throw InvalidCredentialException("인증이 만료되었거나 이메일 인증이 되지 않았습니다")
         }
 
         with(Users) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #184

## 📝작업 내용

> 회원가입 시 이메일 인증이 안된 이메일은 가입이 불가능하고 인증 메일을 보내면 인증코드는 10분 동안 유효하면 인증하지 않으면 인증코드는 사용하지 못합니다 
만약 인증을 했는데 5분 안에 회원가입을 하지 않으면 인증이 풀리도록 하였습니다 
그리고 회원가입이 완료되면 레디스에 있던 이메일 인증 정보는 자동으로 삭제 되도록 하였습니다
(이미 인증된 이메일로 회원가입을 하였기 때문에 인증된 이메일 정보를 남겨둘 필요는 없다고 판단하였습니다)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✏️ 테스트 여부
- [ ] 테스트완료
- (미완료 시) 이유 : 
