### PR TITLE
#191 유저 테스트 이전 기능 개선 및 버그 수정

### DIFF
--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/MatchResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/match/dto/MatchResponse.kt
@@ -14,7 +14,7 @@ data class MatchResponse(
     val matchDate: LocalDateTime,
     val region: Region,
     val location: String,
-    val content: String,
+    val content: String?,
     val matchStatus: Boolean,
     val createdAt: LocalDateTime,
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/dto/response/TeamResponse.kt
@@ -15,7 +15,7 @@ data class TeamResponse(
     val rank: Long?,
     val recruitStatus: Boolean,
     val region: String,
-    val createAt: LocalDateTime
+    val createAt: LocalDateTime?
 ) : Serializable {
     companion object {
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/teamMember/TeamMemberRepository.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/repository/teamMember/TeamMemberRepository.kt
@@ -1,10 +1,18 @@
 package com.teamsparta.tikitaka.domain.team.repository.teamMember
 
+import com.teamsparta.tikitaka.domain.team.model.Team
 import com.teamsparta.tikitaka.domain.team.model.teammember.TeamMember
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface TeamMemberRepository : JpaRepository<TeamMember, Long> {
     fun findByUserId(userId: Long): TeamMember
+
+    @Query("SELECT t FROM TeamMember t WHERE t.userId = :userId")
+    fun findByUserIdOrNull(userId: Long): TeamMember?
+
+    fun findAllByTeamId(teamId: Long): List<TeamMember>
+
     fun findByTeamId(teamId: Long): List<TeamMember>?
     fun findByUserIdAndTeamId(userId: Long, teamId: Long): TeamMember?
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v1/TeamServiceImpl.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v1/TeamServiceImpl.kt
@@ -93,11 +93,20 @@ class TeamServiceImpl(
         teamId: Long
     ) {
         val team = teamRepository.findByIdOrNull(teamId) ?: throw ModelNotFoundException("team", teamId)
-        val teamMember = teamMemberRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
-        val user = usersRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("user", userId)
+        val teamMember = teamMemberRepository.findByUserId(userId)
         if (teamMember.team != team) throw IllegalStateException("팀 삭제 권한이 없습니다.")
-        user.teamStatus = false
+        val teamMembers = teamMemberRepository.findAllByTeamId(teamId)
+        teamMembers.forEach { member ->
+            val memberUser = usersRepository.findByIdOrNull(member.userId)
+                ?: throw ModelNotFoundException("user", member.userId)
+            memberUser.teamStatus = false
+            usersRepository.save(memberUser)
+
+            member.softDelete()
+            teamMemberRepository.save(member)
+        }
         team.softDelete()
+        teamRepository.save(team)
     }
 
     override fun getTeams(

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v2/TeamService2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v2/TeamService2.kt
@@ -3,6 +3,7 @@ package com.teamsparta.tikitaka.domain.team.service.v2
 import com.teamsparta.tikitaka.domain.team.dto.request.TeamRequest
 import com.teamsparta.tikitaka.domain.team.dto.response.PageResponse
 import com.teamsparta.tikitaka.domain.team.dto.response.TeamResponse
+import com.teamsparta.tikitaka.domain.users.dto.NameResponse
 import com.teamsparta.tikitaka.domain.users.dto.UserDto
 import com.teamsparta.tikitaka.domain.users.dto.UserResponse
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
@@ -29,6 +30,6 @@ interface TeamService2 {
         name: String
     ): PageResponse<TeamResponse>
 
-    fun getMyTeam(userPrincipal: UserPrincipal): TeamResponse
+    fun getMyTeam(userPrincipal: UserPrincipal): TeamResponse?
     fun getMyTeamMembers(userPrincipal: UserPrincipal): List<UserResponse>
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v2/TeamServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/team/service/v2/TeamServiceImpl2.kt
@@ -129,8 +129,8 @@ class TeamServiceImpl2(
         return TeamResponse.from(team)
     }
 
-    override fun getMyTeam(userPrincipal: UserPrincipal): TeamResponse {
-        val teamMember = teamMemberRepository.findByUserId(userPrincipal.id)
+    override fun getMyTeam(userPrincipal: UserPrincipal): TeamResponse? {
+        val teamMember = teamMemberRepository.findByUserIdOrNull(userPrincipal.id) ?: throw return null
         return TeamResponse.from(teamMember.team)
     }
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/controller/v2/UsersController2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/controller/v2/UsersController2.kt
@@ -98,12 +98,28 @@ class UsersController2(
             .body(teamService2.getMyTeam(userPrincipal))
     }
 
+    @GetMapping("/oauth-provider")
+    fun getOauthProvider(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ):ResponseEntity<OAuthProviderResponse>{
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(userService.getOAuthProvider(userPrincipal))
+    }
+
     @GetMapping("/my-team-member")
     fun getMyTeamMembers(
         @AuthenticationPrincipal userPrincipal: UserPrincipal
     ): ResponseEntity<List<UserResponse>> {
         return ResponseEntity.status(HttpStatus.OK)
             .body(teamService2.getMyTeamMembers(userPrincipal))
+    }
+
+    @GetMapping("/my-profile")
+    fun getMyProfile(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ):ResponseEntity<NameResponse>{
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(userService.getMyProfile(userPrincipal))
     }
 
 

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/dto/OAuthProviderResponse.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/dto/OAuthProviderResponse.kt
@@ -1,0 +1,15 @@
+package com.teamsparta.tikitaka.domain.users.dto
+
+import com.teamsparta.tikitaka.domain.users.model.Users
+
+data class OAuthProviderResponse(
+    val oAuthProvider: String?
+){
+    companion object {
+        fun from(user: Users): OAuthProviderResponse {
+            return OAuthProviderResponse(
+                oAuthProvider = user.oAuthProvider
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/model/Users.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/model/Users.kt
@@ -38,10 +38,7 @@ class Users(
     var oAuthProvider: String? = null,
 
     @Column(name = "oauth_provider_id")
-    var oAuthProviderId: String? = null,
-
-    @Column(name = "email_enabled")
-    var emailEnabled: Boolean = true,
+    var oAuthProviderId: String? = null
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v2/UsersService2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v2/UsersService2.kt
@@ -1,13 +1,6 @@
 package com.teamsparta.tikitaka.domain.users.service.v2
 
-import com.teamsparta.tikitaka.domain.users.dto.LoginRequest
-import com.teamsparta.tikitaka.domain.users.dto.LoginResponse
-import com.teamsparta.tikitaka.domain.users.dto.NameRequest
-import com.teamsparta.tikitaka.domain.users.dto.NameResponse
-import com.teamsparta.tikitaka.domain.users.dto.PasswordRequest
-import com.teamsparta.tikitaka.domain.users.dto.PasswordResponse
-import com.teamsparta.tikitaka.domain.users.dto.SignUpRequest
-import com.teamsparta.tikitaka.domain.users.dto.UserDto
+import com.teamsparta.tikitaka.domain.users.dto.*
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
 
 interface UsersService2 {
@@ -17,4 +10,6 @@ interface UsersService2 {
     fun validateRefreshTokenAndCreateToken(refreshToken: String): LoginResponse
     fun updateName(request: NameRequest, userPrincipal: UserPrincipal): NameResponse
     fun updatePassword(request: PasswordRequest, userPrincipal: UserPrincipal): PasswordResponse
+    fun getOAuthProvider(userPrincipal: UserPrincipal): OAuthProviderResponse?
+    fun getMyProfile(userPrincipal: UserPrincipal): NameResponse
 }

--- a/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v2/UsersServiceImpl2.kt
+++ b/src/main/kotlin/com/teamsparta/tikitaka/domain/users/service/v2/UsersServiceImpl2.kt
@@ -4,14 +4,7 @@ import com.teamsparta.tikitaka.domain.common.exception.InvalidCredentialExceptio
 import com.teamsparta.tikitaka.domain.common.exception.ModelNotFoundException
 import com.teamsparta.tikitaka.domain.common.util.RedisUtils
 import com.teamsparta.tikitaka.domain.team.repository.teamMember.TeamMemberRepository
-import com.teamsparta.tikitaka.domain.users.dto.LoginRequest
-import com.teamsparta.tikitaka.domain.users.dto.LoginResponse
-import com.teamsparta.tikitaka.domain.users.dto.NameRequest
-import com.teamsparta.tikitaka.domain.users.dto.NameResponse
-import com.teamsparta.tikitaka.domain.users.dto.PasswordRequest
-import com.teamsparta.tikitaka.domain.users.dto.PasswordResponse
-import com.teamsparta.tikitaka.domain.users.dto.SignUpRequest
-import com.teamsparta.tikitaka.domain.users.dto.UserDto
+import com.teamsparta.tikitaka.domain.users.dto.*
 import com.teamsparta.tikitaka.domain.users.model.Users
 import com.teamsparta.tikitaka.domain.users.repository.UsersRepository
 import com.teamsparta.tikitaka.infra.security.UserPrincipal
@@ -126,6 +119,16 @@ class UsersServiceImpl2(
         user.updatePassword(passwordEncoder.encode(request.password))
         usersRepository.save(user)
         return PasswordResponse.from(user)
+    }
+
+    override fun getOAuthProvider(userPrincipal: UserPrincipal): OAuthProviderResponse? {
+        val user = usersRepository.findByIdOrNull(userPrincipal.id) ?: throw return null
+        return OAuthProviderResponse.from(user)
+    }
+
+    override fun getMyProfile(userPrincipal: UserPrincipal): NameResponse {
+        val user = usersRepository.findByIdOrNull(userPrincipal.id) ?: throw ModelNotFoundException("Users", userPrincipal.id)
+        return NameResponse.from(user)
     }
 
     fun isTokenBlacklisted(token: String): Boolean {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #191 

## 📝작업 내용

> 1. 팀 삭제 기능 개선(해당 팀의 모든 유저 status, teamMember도 같이 수정)
2. 내 이름 렌더링 할 수 있게 데이터 전달
3. 일반 로그인, 소셜 로그인 구분하기 위한 데이터 전달

## ✏️ 테스트 여부
- [ ] 테스트완료
